### PR TITLE
Small fix to the Extractor section of the ReadMe

### DIFF
--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -171,8 +171,8 @@ To be able to run the Extractor, you would first need to [install the Azure CLI]
 
 ## Running the Extractor
 Below are the steps to run the Extractor from the source code:
-- Clone this repository and restore its packages using ```dotnet restore```
-- Navigate to {path_to_folder}/src/APIM_ARMTemplate/apimtemplate directory
+- Clone this repository and navigate to {path_to_folder}/src/APIM_ARMTemplate/apimtemplate 
+- Restore its packages using ```dotnet restore```
 - Make sure you have signed in using Azure CLI and have switched to the subscription containing the API Management instance from which the configurations will be extracted. 
 ```
 az login


### PR DESCRIPTION
Quibble: The ReadMe says to run dotnet restore before navigating to the directory where the .sln file lives. dotnet restore will fail, because the .sln file isn't in the current directory. It's not hard to find, but it'll save users time if the steps are technically accurate