### PR TITLE
fix issue with non required api version set. it's uses in file writer.

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
@@ -123,6 +123,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 isValid = false;
                 throw new CommandParsingException(this, "LinkTemplatesBaseUrl is required for linked templates");
             }
+            if(creatorConfig.apiVersionSet == null)
+            {
+                isValid = false;
+                throw new CommandParsingException(this, "API version set is required");
+            }
             if (creatorConfig.apiVersionSet != null && creatorConfig.apiVersionSet.displayName == null)
             {
                 isValid = false;


### PR DESCRIPTION
In FileCreator.cs you're using versionSetName from ApiVersionSet block, but it's not required field and when you don't set it's throwing an exception