### PR TITLE
Checking if isCurrent is False for Revision Creation

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             {
                 name = "name",
                 apiRevision = "2",
-                isCurrent = true,
+                isCurrent = false,
                 suffix = "suffix",
                 subscriptionRequired = true,
                 openApiSpec = "https://petstore.swagger.io/v2/swagger.json",

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             int revisionNumber = 0;
             if (Int32.TryParse(api.apiRevision, out revisionNumber))
             {
-                if (revisionNumber > 1 && api.isCurrent == true)
+                if (revisionNumber > 1 && api.isCurrent == false)
                 {
                     string currentAPIName = api.name;
                     api.name += $";rev={revisionNumber}";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16904871/62575832-390cf600-b861-11e9-8a6a-684fd40da2d6.png)

Deploying to Azure fails when new revision isCurrent==true. Instead this should check if isCurrent==false