### PR TITLE
Correcting to valid ARM code if operation sample value is json array

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -192,35 +192,23 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     operationResource.apiVersion = GlobalConstants.APIVersion;
                     operationResource.scale = null;
 
-                    // add api and schemas to operation dependsOn, if necessary
+                    // add operation dependencies and fix sample value if necessary
                     List<string> operationDependsOn = new List<string>() { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('ApimServiceName'), '{oApiName}')]" };
                     foreach (OperationTemplateRepresentation operationTemplateRepresentation in operationResource.properties.request.representations)
                     {
-                        if (operationTemplateRepresentation.schemaId != null)
-                        {
-                            string dependsOn = $"[resourceId('Microsoft.ApiManagement/service/apis/schemas', parameters('ApimServiceName'), '{oApiName}', '{operationTemplateRepresentation.schemaId}')]";
-                            // add value to list if schema has not already been added
-                            if (!operationDependsOn.Exists(o => o == dependsOn))
-                            {
-                                operationDependsOn.Add(dependsOn);
-                            }
-                        }
+                        AddSchemaDependencyToOperationIfNecessary(oApiName, operationDependsOn, operationTemplateRepresentation);
+                        ArmEscapeSampleValueIfNecessary(operationTemplateRepresentation);
                     }
+
                     foreach (OperationsTemplateResponse operationTemplateResponse in operationResource.properties.responses)
                     {
                         foreach (OperationTemplateRepresentation operationTemplateRepresentation in operationTemplateResponse.representations)
                         {
-                            if (operationTemplateRepresentation.schemaId != null)
-                            {
-                                string dependsOn = $"[resourceId('Microsoft.ApiManagement/service/apis/schemas', parameters('ApimServiceName'), '{oApiName}', '{operationTemplateRepresentation.schemaId}')]";
-                                // add value to list if schema has not already been added
-                                if (!operationDependsOn.Exists(o => o == dependsOn))
-                                {
-                                    operationDependsOn.Add(dependsOn);
-                                }
-                            }
+                            AddSchemaDependencyToOperationIfNecessary(oApiName, operationDependsOn, operationTemplateRepresentation);
+                            ArmEscapeSampleValueIfNecessary(operationTemplateRepresentation);
                         }
                     }
+
                     operationResource.dependsOn = operationDependsOn.ToArray();
                     templateResources.Add(operationResource);
 
@@ -342,7 +330,28 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return armTemplate;
         }
 
-        public static JObject FormatoApi(string singleApiName, JObject oApi)
+        private static void ArmEscapeSampleValueIfNecessary(OperationTemplateRepresentation operationTemplateRepresentation)
+        {
+            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType == "application/json" && JToken.Parse(operationTemplateRepresentation.sample).Type == JTokenType.Array)
+            {
+                operationTemplateRepresentation.sample = "[" + operationTemplateRepresentation.sample;
+            }
+        }
+
+        private static void AddSchemaDependencyToOperationIfNecessary(string oApiName, List<string> operationDependsOn, OperationTemplateRepresentation operationTemplateRepresentation)
+        {
+            if (operationTemplateRepresentation.schemaId != null)
+            {
+                string dependsOn = $"[resourceId('Microsoft.ApiManagement/service/apis/schemas', parameters('ApimServiceName'), '{oApiName}', '{operationTemplateRepresentation.schemaId}')]";
+                // add value to list if schema has not already been added
+                if (!operationDependsOn.Exists(o => o == dependsOn))
+                {
+                    operationDependsOn.Add(dependsOn);
+                }
+            }
+        }
+
+        private static JObject FormatoApi(string singleApiName, JObject oApi)
         {
             if (singleApiName != null)
             {
@@ -364,7 +373,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return oApi;
         }
 
-        public async Task<List<TemplateResource>> GenerateSchemasARMTemplate(string apimServiceName, string apiName, string resourceGroup, string fileFolder)
+        private async Task<List<TemplateResource>> GenerateSchemasARMTemplate(string apimServiceName, string apiName, string resourceGroup, string fileFolder)
         {
             List<TemplateResource> templateResources = new List<TemplateResource>();
 


### PR DESCRIPTION
The Azure API will return the samples as escaped json. When the sample is an array the reponse will be similar to
```[{ \"Id\": 1, \"Name\": \"Jane Doe\" }, { \"Id\": 2, \"Name\": \"John Doe\" }]```

When inserting this directly into the ARM template this gives an error as square brackets are used for functions in ARM. So we need to ARM escape it, which is done by starting off with double square bracket `[[`, leading to a valid ARM template:

```
...
        "responses": [
          {
            "statusCode": 200,
            "description": "successful operation",
            "headers": [],
            "representations": [
              {
                "contentType": "application/json",
                "sample": "[[{ \"Id\": 1, \"Name\": \"Jane Doe\" }, { \"Id\": 2, \"Name\": \"John Doe\" }]",
                "schemaId": "5d8ba37d0fde42181809008b",
                "typeName": "PeopleArray"
              }
            ]
          },
...
```
Code checks if content type is application/json and an array, and then fixes the sample value.

This pull request will fix #242.