### PR TITLE
[Creator] support add tags to API

### DIFF
--- a/example/master.template.json
+++ b/example/master.template.json
@@ -99,7 +99,7 @@
                }
             },
             "dependsOn": [
-             "[resourceId('Microsoft.Resources/deployments', 'serviceTemplate')]",
+             "[resourceId('Microsoft.Resources/deployments', 'serviceTemplate')]"
             ]
          },
          {

--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorFactories/APITemplateCreatorFactory.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorFactories/APITemplateCreatorFactory.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             ProductAPITemplateCreator productAPITemplateCreator = new ProductAPITemplateCreator();
             DiagnosticTemplateCreator diagnosticTemplateCreator = new DiagnosticTemplateCreator();
             ReleaseTemplateCreator releaseTemplateCreator = new ReleaseTemplateCreator();
-            APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, productAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
+            TagAPITemplateCreator tagAPITemplateCreator = new TagAPITemplateCreator();
+            APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, productAPITemplateCreator, tagAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
             return apiTemplateCreator;
         }
     }

--- a/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
@@ -42,12 +42,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     BackendTemplateCreator backendTemplateCreator = new BackendTemplateCreator();
                     AuthorizationServerTemplateCreator authorizationServerTemplateCreator = new AuthorizationServerTemplateCreator();
                     ProductAPITemplateCreator productAPITemplateCreator = new ProductAPITemplateCreator();
+                    TagAPITemplateCreator tagAPITemplateCreator = new TagAPITemplateCreator();
                     PolicyTemplateCreator policyTemplateCreator = new PolicyTemplateCreator(fileReader);
                     DiagnosticTemplateCreator diagnosticTemplateCreator = new DiagnosticTemplateCreator();
                     ReleaseTemplateCreator releaseTemplateCreator = new ReleaseTemplateCreator();
                     ProductTemplateCreator productTemplateCreator = new ProductTemplateCreator(policyTemplateCreator);
                     TagTemplateCreator tagTemplateCreator = new TagTemplateCreator();
-                    APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, productAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
+                    APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, productAPITemplateCreator, tagAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
                     MasterTemplateCreator masterTemplateCreator = new MasterTemplateCreator();
 
                     // create templates from provided configuration
@@ -60,9 +61,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     Console.WriteLine("Creating product template");
                     Console.WriteLine("------------------------------------------");
                     Template productsTemplate = creatorConfig.products != null ? productTemplateCreator.CreateProductTemplate(creatorConfig) : null;
-                    Console.WriteLine("Creating tag template");
-                    Console.WriteLine("------------------------------------------");
-                    Template tagTemplate = creatorConfig.tags != null ? tagTemplateCreator.CreateTagTemplate(creatorConfig) : null;
                     Console.WriteLine("Creating logger template");
                     Console.WriteLine("------------------------------------------");
                     Template loggersTemplate = creatorConfig.loggers != null ? loggerTemplateCreator.CreateLoggerTemplate(creatorConfig) : null;
@@ -97,6 +95,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                             dependsOnBackends = await masterTemplateCreator.DetermineIfAPIDependsOnBackendAsync(api, fileReader)
                         });
                     }
+
+                    Console.WriteLine("Creating tag template");
+                    Console.WriteLine("------------------------------------------");
+                    Template tagTemplate = creatorConfig.tags != null ? tagTemplateCreator.CreateTagTemplate(creatorConfig) : null;
 
                     // create parameters file
                     Template templateParameters = masterTemplateCreator.CreateMasterTemplateParameterValues(creatorConfig);

--- a/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/TagAPITemplateResource.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/TagAPITemplateResource.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
+{
+    public class TagAPITemplateResource : TemplateResource
+    {
+        public TagAPITemplateProperties properties { get; set; }
+    }
+
+    public class TagAPITemplateProperties
+    {
+        public string displayName { get; set; }
+    }
+}

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -10,14 +10,16 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
         private FileReader fileReader;
         private PolicyTemplateCreator policyTemplateCreator;
         private ProductAPITemplateCreator productAPITemplateCreator;
+        private TagAPITemplateCreator tagAPITemplateCreator;
         private DiagnosticTemplateCreator diagnosticTemplateCreator;
         private ReleaseTemplateCreator releaseTemplateCreator;
 
-        public APITemplateCreator(FileReader fileReader, PolicyTemplateCreator policyTemplateCreator, ProductAPITemplateCreator productAPITemplateCreator, DiagnosticTemplateCreator diagnosticTemplateCreator, ReleaseTemplateCreator releaseTemplateCreator)
+        public APITemplateCreator(FileReader fileReader, PolicyTemplateCreator policyTemplateCreator, ProductAPITemplateCreator productAPITemplateCreator, TagAPITemplateCreator tagAPITemplateCreator, DiagnosticTemplateCreator diagnosticTemplateCreator, ReleaseTemplateCreator releaseTemplateCreator)
         {
             this.fileReader = fileReader;
             this.policyTemplateCreator = policyTemplateCreator;
             this.productAPITemplateCreator = productAPITemplateCreator;
+            this.tagAPITemplateCreator = tagAPITemplateCreator;
             this.diagnosticTemplateCreator = diagnosticTemplateCreator;
             this.releaseTemplateCreator = releaseTemplateCreator;
         }
@@ -87,6 +89,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             PolicyTemplateResource apiPolicyResource = api.policy != null ? this.policyTemplateCreator.CreateAPIPolicyTemplateResource(api, dependsOn) : null;
             List<PolicyTemplateResource> operationPolicyResources = api.operations != null ? this.policyTemplateCreator.CreateOperationPolicyTemplateResources(api, dependsOn) : null;
             List<ProductAPITemplateResource> productAPIResources = api.products != null ? this.productAPITemplateCreator.CreateProductAPITemplateResources(api, dependsOn) : null;
+            List<TagAPITemplateResource> tagAPIResources = api.tags != null ? this.tagAPITemplateCreator.CreateTagAPITemplateResources(api,dependsOn) : null;
             DiagnosticTemplateResource diagnosticTemplateResource = api.diagnostic != null ? this.diagnosticTemplateCreator.CreateAPIDiagnosticTemplateResource(api, dependsOn) : null;
             // add release resource if the name has been appended with ;rev{revisionNumber}
             ReleaseTemplateResource releaseTemplateResource = api.name.Contains(";rev") == true ? this.releaseTemplateCreator.CreateAPIReleaseTemplateResource(api, dependsOn) : null;
@@ -95,6 +98,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             if (apiPolicyResource != null) resources.Add(apiPolicyResource);
             if (operationPolicyResources != null) resources.AddRange(operationPolicyResources);
             if (productAPIResources != null) resources.AddRange(productAPIResources);
+            if (tagAPIResources != null) resources.AddRange(tagAPIResources);
             if (diagnosticTemplateResource != null) resources.Add(diagnosticTemplateResource);
             if (releaseTemplateResource != null) resources.Add(releaseTemplateResource);
 

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/TagAPITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/TagAPITemplateCreator.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
+{
+    public class TagAPITemplateCreator
+    {
+        public TagAPITemplateResource CreateTagAPITemplateResource(string tagName, string apiName, string[] dependsOn)
+        {
+            // create tags/apis resource with properties
+            TagAPITemplateResource tagAPITemplateResource = new TagAPITemplateResource(){
+                name = $"[concat(parameters('ApimServiceName'), '/{apiName}/{tagName}')]",
+                type = ResourceTypeConstants.APITag,
+                apiVersion = GlobalConstants.APIVersion,
+                properties = new TagAPITemplateProperties(){
+                    displayName = tagName
+                },
+                dependsOn = dependsOn
+            };
+            return tagAPITemplateResource;
+        }
+
+        public List<TagAPITemplateResource> CreateTagAPITemplateResources(APIConfig api, string[] dependsOn)
+        {
+            // create a tag/apis association resource for each tag in the config file
+            List<TagAPITemplateResource> tagAPITemplates = new List<TagAPITemplateResource>();
+            // tags is comma seperated list pf tags
+            string[] tagIDs = api.tags.Split(", ");
+            foreach(string tagID in tagIDs) 
+            {
+                TagAPITemplateResource tagAPITemplate = this.CreateTagAPITemplateResource(tagID, api.name, dependsOn);
+                tagAPITemplates.Add(tagAPITemplate);
+            }
+            return tagAPITemplates;
+        }
+    }
+}

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/TagTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/TagTemplateCreator.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 {
-    public class TagTemplateCreator: TemplateCreator
+    public class TagTemplateCreator : TemplateCreator
     {
         public Template CreateTagTemplate(CreatorConfig creatorConfig)
         {
@@ -18,20 +18,27 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             };
 
             // aggregate all tags from apis
-            HashSet<string> tagHashset = new HashSet<string>(); 
+            HashSet<string> tagHashset = new HashSet<string>();
             List<APIConfig> apis = creatorConfig.apis;
-            foreach(APIConfig api in apis) 
+            if (apis != null)
             {
-                string[] apiTags = api.tags.Split(", ");
-                foreach(string apiTag in apiTags) {
-                    tagHashset.Add(apiTag);
+                foreach (APIConfig api in apis)
+                {
+                    if (api.tags != null)
+                    {
+                        string[] apiTags = api.tags.Split(", ");
+                        foreach (string apiTag in apiTags)
+                        {
+                            tagHashset.Add(apiTag);
+                        }
+                    }
                 }
             }
-            foreach(TagTemplateProperties tag in creatorConfig.tags)
+            foreach (TagTemplateProperties tag in creatorConfig.tags)
             {
                 tagHashset.Add(tag.displayName);
             }
-            
+
             List<TemplateResource> resources = new List<TemplateResource>();
             foreach (string tag in tagHashset)
             {

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/TagTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/TagTemplateCreator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
+using System;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 {
@@ -16,18 +17,33 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 {"ApimServiceName", new TemplateParameterProperties(){ type = "string" }}
             };
 
+            // aggregate all tags from apis
+            HashSet<string> tagHashset = new HashSet<string>(); 
+            List<APIConfig> apis = creatorConfig.apis;
+            foreach(APIConfig api in apis) 
+            {
+                string[] apiTags = api.tags.Split(", ");
+                foreach(string apiTag in apiTags) {
+                    tagHashset.Add(apiTag);
+                }
+            }
+            foreach(TagTemplateProperties tag in creatorConfig.tags)
+            {
+                tagHashset.Add(tag.displayName);
+            }
+            
             List<TemplateResource> resources = new List<TemplateResource>();
-            foreach (TagTemplateProperties tag in creatorConfig.tags)
+            foreach (string tag in tagHashset)
             {
                 // create tag resource with properties
                 TagTemplateResource tagTemplateResource = new TagTemplateResource()
                 {
-                    name = $"[concat(parameters('ApimServiceName'), '/{tag.displayName}')]",
+                    name = $"[concat(parameters('ApimServiceName'), '/{tag}')]",
                     type = ResourceTypeConstants.Tag,
                     apiVersion = GlobalConstants.APIVersion,
                     properties = new TagTemplateProperties()
                     {
-                        displayName = tag.displayName
+                        displayName = tag
                     },
                     dependsOn = new string[] { }
                 };


### PR DESCRIPTION
1. If tag doesn't exist in destination apim, it will automatically add all tags used in the swagger files (include operations, apis) to the apim
2. We can create apis with tags and create the corresponding tags

Close #263 