### PR TITLE
[Extractor]create better file structure for splitAPIs

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Common/FileHandlers/FileNameGenerator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/FileHandlers/FileNameGenerator.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
                 parameters = $@"/{apimServiceName}-parameters.json",
                 linkedMaster = $@"/{apimServiceName}-master.template.json",
                 apis = "/Apis",
-                splitAPIs = "/SplitAPIs"
+                splitAPIs = "/SplitAPIs",
+                versionSetMasterFolder = "/VersionSetMasterFolder"
             };
         }
 
@@ -67,5 +68,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public string linkedMaster { get; set; }
         public string apis { get; set; }
         public string splitAPIs { get; set; }
+        public string versionSetMasterFolder { get; set; }
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Common/FileHandlers/FileNameGenerator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/FileHandlers/FileNameGenerator.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
                 tags = $@"/{apimServiceName}-tags.template.json",
                 products = $@"/{apimServiceName}-products.template.json",
                 parameters = $@"/{apimServiceName}-parameters.json",
-                linkedMaster = $@"/{apimServiceName}-master.template.json"
+                linkedMaster = $@"/{apimServiceName}-master.template.json",
+                apis = "/Apis",
+                splitAPIs = "/SplitAPIs"
             };
         }
 
@@ -63,5 +65,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public string parameters { get; set; }
         // linked property outputs 1 master template
         public string linkedMaster { get; set; }
+        public string apis { get; set; }
+        public string splitAPIs { get; set; }
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 resources.Add(this.CreateLinkedMasterTemplateResource("productsTemplate", productsUri, dependsOnNamedValues));
             }
 
-            if (tagTemplate != null) {
+            if (tagTemplate != null)
+            {
                 string tagUri = GenerateLinkedTemplateUri(linkedTemplatesUrlQueryString, fileNames.tags);
                 resources.Add(this.CreateLinkedMasterTemplateResource("tagTemplate", tagUri, dependsOnNamedValues));
             }
@@ -141,7 +142,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     parameters = new Dictionary<string, TemplateParameterProperties>
                     {
                         { "ApimServiceName", new TemplateParameterProperties(){ value = "[parameters('ApimServiceName')]" } },
-                        { "PolicyXMLBaseUrl", new TemplateParameterProperties(){ value = "[parameters('PolicyXMLBaseUrl')]" } }                        
+                        { "PolicyXMLBaseUrl", new TemplateParameterProperties(){ value = "[parameters('PolicyXMLBaseUrl')]" } }
                     }
                 },
                 dependsOn = dependsOn


### PR DESCRIPTION
1. -- SplitApis create better file structure: if there is an APIVersionSet, all apis belong to this version set will be in a same folder
2. Created a master template (with related templates) in apiVersionSetMaster to deploy apis within this apiVersionSet at a time
3. Refactor code

Close #267

pic shows the folder structure
![image](https://user-images.githubusercontent.com/29927264/69455159-a2cfe380-0d1c-11ea-8612-56ef73376da0.png)