### PR TITLE
[Extractor] #264 Fixed generated ARM resource for schemas of type OpenAPI so that…

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/SchemaTemplateResource.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/SchemaTemplateResource.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
     public class SchemaTemplateDocument
     {
         public string value { get; set; }
+
+        public dynamic components { get; set; }
     }
 
     public class RESTReturnedSchemaTemplate : APITemplateSubResource

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -494,6 +494,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
         private string GetSchemaValueBasedOnContentType(RESTReturnedSchemaTemplateProperties schemaTemplateProperties)
         {
+            var contentType = schemaTemplateProperties.contentType.ToLowerInvariant();
+            if (contentType.Equals("application/vnd.oai.openapi.components+json"))
+            {
+                // for OpenAPI "value" is not used, but "components" which is resolved during json deserialization
+                return null;
+            }
+
             if (!(schemaTemplateProperties.document is JToken))
             {
                 return JsonConvert.SerializeObject(schemaTemplateProperties.document);
@@ -501,7 +508,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
             var schemaJson = schemaTemplateProperties.document as JToken;
 
-            switch (schemaTemplateProperties.contentType.ToLowerInvariant())
+            switch (contentType)
             {
                 case "application/vnd.ms-azure-apim.swagger.definitions+json":
                     if (schemaJson["definitions"] != null && schemaJson.Count() == 1)


### PR DESCRIPTION
… definitions will survive extract+deployment.

Fixes #264.

For OpenAPI `components` are used instead of `value`. Added as dynamic since it's json and it's then being resolved by the default json deserializer. Setting `value` to null when contenttype is `application/vnd.oai.openapi.components+json`. When serializing to json the extractor is using setting `NullValueHandling.Ignore` which means that the different schema's only get the one applicable `components` or `value` property when ARM template is generated.