### PR TITLE
Fix example master template, Creator demo YAML config and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ project.lock.json
 nupkg/
 
 # Visual Studio Code
-.vscode
+.vscode/**
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "azureResourceManagerTools.checkForLatestSchema": false
+}

--- a/example/demo/Input/valid.yml
+++ b/example/demo/Input/valid.yml
@@ -1,34 +1,34 @@
 version: 0.0.1   # Required
 apimServiceName: contosoapim-dev   # Required, must match name of an apim service deployed in the specified resource group
 apiVersionSet:   # Optional
-    id: myVersionSetID
+  - id: myVersionSetID
     displayName: myAPIVersionSet
     description: a description
     versioningScheme: Query
     versionQueryName: versionQuery
     versionHeaderName: versionHeader
-api:
-  name: myAPI   # Required
-  openApiSpec: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Input/swaggerPetstore.json    # Required, can be url or local file
-  #openApiSpec: https://petstore.swagger.io/v2/swagger.json
-  policy: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Input/apiPolicyHeaders.xml   # Optional, can be url or local file
-  suffix: myAPIPet   # Required
-  apiVersion: v1   # Optional
-  apiVersionDescription: My first version   # Optional 
-  apiVersionSetId: myVersionSetID
-  revision: 1   # Optional
-  revisionDescription: My first revision   # Optional
-  operations:   # Optional
-    addPet: # Must match the operationId property of a path's operations
-      policy: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Input/operationRateLimit.xml   # Optional, can be url or local file
-    deletePet:  # Must match the operationId property of a path's operations
-      policy: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Input/operationRateLimit.xml   # Optional, can be url or local file
-  authenticationSettings:   # Optional
-    subscriptionKeyRequired: false
-    #oAuth2:
-    #    authorizationServerId: apimgmtaad
-    #    scope: scope
-  products: starter    # Optional, adds api to the specified products
+apis:
+  - name: myAPI   # Required
+    openApiSpec: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Input/swaggerPetstore.json    # Required, can be url or local file
+    #openApiSpec: https://petstore.swagger.io/v2/swagger.json
+    policy: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Input/apiPolicyHeaders.xml   # Optional, can be url or local file
+    suffix: myAPIPet   # Required
+    apiVersion: v1   # Optional
+    apiVersionDescription: My first version   # Optional
+    apiVersionSetId: myVersionSetID
+    revision: 1   # Optional
+    revisionDescription: My first revision   # Optional
+    operations:   # Optional
+      addPet: # Must match the operationId property of a path's operations
+        policy: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Input/operationRateLimit.xml   # Optional, can be url or local file
+      deletePet:  # Must match the operationId property of a path's operations
+        policy: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Input/operationRateLimit.xml   # Optional, can be url or local file
+    authenticationSettings:   # Optional
+      subscriptionKeyRequired: false
+      #oAuth2:
+      #    authorizationServerId: apimgmtaad
+      #    scope: scope
+    products: starter    # Optional, adds api to the specified products
 outputLocation: /Users/miaojiang/Work/azure-api-management-devops-example/example/demo/Output   # Required, folder the creator will write the templates to
 linked: true   # Optional
 linkedTemplatesBaseUrl : https://raw.githubusercontent.com/miaojiang/azure-api-management-devops-example/MVP/example/demo/Output  # Required if 'linked' property is set to true

--- a/example/master.template.json
+++ b/example/master.template.json
@@ -58,7 +58,7 @@
                  "contentVersion":"1.0.0.0"
               },
               "parameters": {
-                "ApimServiceName": {"value": "[parameters('ApimServiceName')]" }, 
+                "ApimServiceName": {"value": "[parameters('ApimServiceName')]" },
                 "PublisherName": {"value": "[parameters('PublisherName')]" },
                 "PublisherEmail": {"value": "[parameters('PublisherEmail')]" },
                 "sku": {"value": "[parameters('sku')]" },
@@ -109,7 +109,7 @@
             "properties": {
               "mode": "Incremental",
               "templateLink": {
-                 "uri":"[concat(parameters('repoBaseUrl'), '/product-starter/product-starter.template.json')]",
+                 "uri":"[concat(parameters('repoBaseUrl'), '/products/product-starter.template.json')]",
                  "contentVersion":"1.0.0.0"
               },
               "parameters": {

--- a/example/master.template.json
+++ b/example/master.template.json
@@ -113,8 +113,7 @@
                  "contentVersion":"1.0.0.0"
               },
               "parameters": {
-                 "ApimServiceName": {"value": "[parameters('ApimServiceName')]" },
-                 "repoBaseUrl": {"value": "[parameters('repoBaseUrl')]" }
+                 "ApimServiceName": {"value": "[parameters('ApimServiceName')]" }
                }
             },
             "dependsOn": [
@@ -189,8 +188,7 @@
                  "contentVersion":"1.0.0.0"
               },
               "parameters": {
-                 "ApimServiceName": {"value": "[parameters('ApimServiceName')]" },
-                 "repoBaseUrl": {"value": "[parameters('repoBaseUrl')]" }
+                 "ApimServiceName": {"value": "[parameters('ApimServiceName')]" }
                }
             },
             "dependsOn": [
@@ -209,8 +207,7 @@
                  "contentVersion":"1.0.0.0"
               },
               "parameters": {
-                 "ApimServiceName": {"value": "[parameters('ApimServiceName')]" },
-                 "repoBaseUrl": {"value": "[parameters('repoBaseUrl')]" }
+                 "ApimServiceName": {"value": "[parameters('ApimServiceName')]" }
                }
             },
             "dependsOn": [


### PR DESCRIPTION
1. Fixed re-include of files in .vscode directory. See https://git-scm.com/docs/gitignore
> It is not possible to re-include a file if a parent directory of that file is excluded.

2. Added VS Code setting to ignore old ARM templates schemas.
3. Fixed example master template (example/master.template.json). Now Azure Portal can import it without errors.
4. Fixed demo config for Creator (example/demo/Input/valid.yml). Now it runs without errors.
