### PR TITLE
Sastoken

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Creator/Models/ExtractorConfiguration.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/Models/ExtractorConfiguration.cs
@@ -9,8 +9,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         public string apiName { get; set; }
         public string mutipleAPIs { get; set; }
         public string linkedTemplatesBaseUrl { get; set; }
+        public string linkedTemplatesSasToken { get; set; }
         public string linkedTemplatesUrlQueryString { get; set; }
         public string policyXMLBaseUrl { get; set; }
+        public string policyXMLSasToken { get; set; }
         public string splitAPIs { get; set; }
         public string apiVersionSetName { get; set; }
         public string includeAllRevisions { get; set; }
@@ -23,8 +25,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         public string resourceGroup { get; private set; }
         public string fileFolder { get; private set; }
         public string linkedTemplatesBaseUrl { get; private set; }
+        public string linkedTemplatesSasToken { get; private set; }
         public string linkedTemplatesUrlQueryString { get; private set; }
         public string policyXMLBaseUrl { get; private set; }
+        public string policyXMLSasToken { get; private set; }
         public string apiVersionSetName { get; private set; }
         public bool includeAllRevisions { get; private set; }
 
@@ -35,8 +39,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             this.resourceGroup = exc.resourceGroup;
             this.fileFolder = dirName;
             this.linkedTemplatesBaseUrl = exc.linkedTemplatesBaseUrl;
+            this.linkedTemplatesSasToken = exc.linkedTemplatesSasToken;
             this.linkedTemplatesUrlQueryString = exc.linkedTemplatesUrlQueryString;
             this.policyXMLBaseUrl = exc.policyXMLBaseUrl;
+            this.policyXMLSasToken = exc.policyXMLSasToken;
             this.apiVersionSetName = exc.apiVersionSetName;
             this.includeAllRevisions = checkIncludeRevision(exc.includeAllRevisions);
         }
@@ -48,8 +54,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             this.resourceGroup = exc.resourceGroup;
             this.fileFolder = exc.fileFolder;
             this.linkedTemplatesBaseUrl = exc.linkedTemplatesBaseUrl;
+            this.linkedTemplatesSasToken = exc.linkedTemplatesSasToken;
             this.linkedTemplatesUrlQueryString = exc.linkedTemplatesUrlQueryString;
             this.policyXMLBaseUrl = exc.policyXMLBaseUrl;
+            this.policyXMLSasToken = exc.policyXMLSasToken;
             this.apiVersionSetName = exc.apiVersionSetName;
             this.includeAllRevisions = checkIncludeRevision(exc.includeAllRevisions);
         }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -771,7 +771,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             // when extract all APIs and generate one master template
             else
             {
-                JToken[] oApis = await GetAllAPIObjsAsync(apimname, resourceGroup, policyXMLBaseUrl);
+                JToken[] oApis = await GetAllAPIObjsAsync(apimname, resourceGroup);
                 Console.WriteLine("{0} APIs found ...", (oApis.Count().ToString()));
 
                 foreach (JToken oApi in oApis)

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<List<TemplateResource>> GenerateSingleAPIResourceAsync(string apiName, string apimname, string resourceGroup, string fileFolder, string policyXMLBaseUrl)
+        public async Task<List<TemplateResource>> GenerateSingleAPIResourceAsync(string apiName, string apimname, string resourceGroup, string fileFolder, string policyXMLBaseUrl, string policyXMLSasToken)
         {
             List<TemplateResource> templateResources = new List<TemplateResource>();
             string apiDetails = await GetAPIDetailsAsync(apimname, resourceGroup, apiName);
@@ -286,7 +286,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                         this.fileWriter.CreateFolderIfNotExists(policyFolder);
                         this.fileWriter.WriteXMLToFile(policyXMLContent, String.Concat(policyFolder, operationPolicyFileName));
                         operationPolicyResource.properties.format = "rawxml-link";
-                        operationPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{operationPolicyFileName}')]";
+                        if (policyXMLSasToken != null)
+                        {
+                            operationPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{operationPolicyFileName}', parameters('PolicyXMLSasToken'))]";
+                        }
+                        else
+                        {
+                            operationPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{operationPolicyFileName}')]";
+                        }
                     }
 
                     templateResources.Add(operationPolicyResource);
@@ -340,7 +347,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     this.fileWriter.CreateFolderIfNotExists(policyFolder);
                     this.fileWriter.WriteXMLToFile(policyXMLContent, String.Concat(policyFolder, apiPolicyFileName));
                     apiPoliciesResource.properties.format = "rawxml-link";
-                    apiPoliciesResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{apiPolicyFileName}')]";
+                    if (policyXMLSasToken != null)
+                    {
+                        apiPoliciesResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{apiPolicyFileName}', parameters('PolicyXMLSasToken'))]";
+                    }
+                    else
+                    {
+                        apiPoliciesResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{apiPolicyFileName}')]";
+                    }
                 }
                 templateResources.Add(apiPoliciesResource);
             }
@@ -432,11 +446,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         public async Task<Template> GenerateAPIRevisionTemplateAsync(string currentRevision, List<string> revList, string apiName, Extractor exc)
         {
             // generate apiTemplate
-            Template armTemplate = GenerateEmptyTemplateWithParameters(exc.policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(exc.policyXMLBaseUrl, exc.policyXMLSasToken);
             List<TemplateResource> templateResources = new List<TemplateResource>();
             Console.WriteLine("{0} APIs found ...", revList.Count().ToString());
 
-            List<TemplateResource> apiResources = await GenerateSingleAPIResourceAsync(apiName, exc.sourceApimName, exc.resourceGroup, exc.fileFolder, exc.policyXMLBaseUrl);
+            List<TemplateResource> apiResources = await GenerateSingleAPIResourceAsync(apiName, exc.sourceApimName, exc.resourceGroup, exc.fileFolder, exc.policyXMLBaseUrl, exc.policyXMLSasToken);
             templateResources.AddRange(apiResources);
 
             foreach (string curApi in revList)
@@ -445,14 +459,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 if (curApi.Equals(currentRevision))
                 {
                     // add current API revision resource to template
-                    apiResources = await GenerateCurrentRevisionAPIResourceAsync(curApi, exc.sourceApimName, exc.resourceGroup, exc.fileFolder, exc.policyXMLBaseUrl);
+                    apiResources = await GenerateCurrentRevisionAPIResourceAsync(curApi, exc.sourceApimName, exc.resourceGroup, exc.fileFolder, exc.policyXMLBaseUrl, exc.policyXMLSasToken);
                     templateResources.AddRange(apiResources);
                 }
                 else
                 {
                     // add other API revision resources to template
-                    apiResources = await GenerateSingleAPIResourceAsync(curApi, exc.sourceApimName, exc.resourceGroup, exc.fileFolder, exc.policyXMLBaseUrl);
-
+                    apiResources = await GenerateSingleAPIResourceAsync(curApi, exc.sourceApimName, exc.resourceGroup, exc.fileFolder, exc.policyXMLBaseUrl, exc.policyXMLSasToken);
+                    
                     // make current API a dependency to other revisions, in case destination apim doesn't have the this API 
                     TemplateResource apiResource = apiResources.FirstOrDefault(resource => resource.type == ResourceTypeConstants.API) as TemplateResource;
                     List<TemplateResource> newResourcesList = ExtractorUtils.removeResourceType(ResourceTypeConstants.API, apiResources);
@@ -470,7 +484,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         }
 
         // this function will get the current revision of this api and will remove "isCurrent" paramter
-        public async Task<List<TemplateResource>> GenerateCurrentRevisionAPIResourceAsync(string apiName, string apimname, string resourceGroup, string fileFolder, string policyXMLBaseUrl)
+        public async Task<List<TemplateResource>> GenerateCurrentRevisionAPIResourceAsync(string apiName, string apimname, string resourceGroup, string fileFolder, string policyXMLBaseUrl, string policyXMLSasToken)
         {
             List<TemplateResource> templateResources = new List<TemplateResource>();
             string apiDetails = await GetAPIDetailsAsync(apimname, resourceGroup, apiName);
@@ -568,7 +582,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                         this.fileWriter.CreateFolderIfNotExists(policyFolder);
                         this.fileWriter.WriteXMLToFile(policyXMLContent, String.Concat(policyFolder, operationPolicyFileName));
                         operationPolicyResource.properties.format = "rawxml-link";
-                        operationPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{operationPolicyFileName}')]";
+                        if (policyXMLSasToken != null)
+                        {
+                            operationPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{operationPolicyFileName}', parameters('PolicyXMLSasToken'))]";
+                        }
+                        else
+                        {
+                            operationPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{operationPolicyFileName}')]";
+                        }
                     }
 
                     templateResources.Add(operationPolicyResource);
@@ -622,7 +643,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     this.fileWriter.CreateFolderIfNotExists(policyFolder);
                     this.fileWriter.WriteXMLToFile(policyXMLContent, String.Concat(policyFolder, apiPolicyFileName));
                     apiPoliciesResource.properties.format = "rawxml-link";
-                    apiPoliciesResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{apiPolicyFileName}')]";
+                    if (policyXMLSasToken != null)
+                    {
+                        apiPoliciesResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{apiPolicyFileName}', parameters('PolicyXMLSasToken'))]";
+                    }
+                    else
+                    {
+                        apiPoliciesResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{apiPolicyFileName}')]";
+                    }
                 }
                 templateResources.Add(apiPoliciesResource);
             }
@@ -710,10 +738,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return templateResources;
         }
 
-        public async Task<Template> GenerateAPIsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<string> multipleApiNames, string policyXMLBaseUrl, string fileFolder)
+        public async Task<Template> GenerateAPIsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<string> multipleApiNames, string policyXMLBaseUrl, string policyXMLSasToken, string fileFolder)
         {
             // initialize arm template
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
             List<TemplateResource> templateResources = new List<TemplateResource>();
 
             // when extract single API
@@ -724,7 +752,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 {
                     string apiDetails = await GetAPIDetailsAsync(apimname, resourceGroup, singleApiName);
                     Console.WriteLine("{0} API found ...", singleApiName);
-                    templateResources.AddRange(await GenerateSingleAPIResourceAsync(singleApiName, apimname, resourceGroup, fileFolder, policyXMLBaseUrl));
+                    templateResources.AddRange(await GenerateSingleAPIResourceAsync(singleApiName, apimname, resourceGroup, fileFolder, policyXMLBaseUrl, policyXMLSasToken));
                 }
                 catch (Exception)
                 {
@@ -737,19 +765,19 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 Console.WriteLine("{0} APIs found ...", multipleApiNames.Count().ToString());
                 foreach (string apiName in multipleApiNames)
                 {
-                    templateResources.AddRange(await GenerateSingleAPIResourceAsync(apiName, apimname, resourceGroup, fileFolder, policyXMLBaseUrl));
+                    templateResources.AddRange(await GenerateSingleAPIResourceAsync(apiName, apimname, resourceGroup, fileFolder, policyXMLBaseUrl, policyXMLSasToken));
                 }
             }
             // when extract all APIs and generate one master template
             else
             {
-                JToken[] oApis = await GetAllAPIObjsAsync(apimname, resourceGroup);
+                JToken[] oApis = await GetAllAPIObjsAsync(apimname, resourceGroup, policyXMLBaseUrl);
                 Console.WriteLine("{0} APIs found ...", (oApis.Count().ToString()));
 
                 foreach (JToken oApi in oApis)
                 {
                     string apiName = ((JValue)oApi["name"]).Value.ToString();
-                    templateResources.AddRange(await GenerateSingleAPIResourceAsync(apiName, apimname, resourceGroup, fileFolder, policyXMLBaseUrl));
+                    templateResources.AddRange(await GenerateSingleAPIResourceAsync(apiName, apimname, resourceGroup, fileFolder, policyXMLBaseUrl, policyXMLSasToken));
                 }
             }
             armTemplate.resources = templateResources.ToArray();

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIVersionSetExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIVersionSetExtractor.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateAPIVersionSetsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl)
+        public async Task<Template> GenerateAPIVersionSetsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl, string policyXMLSasToken)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting API version sets from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
 
             // isolate apis in the case of a single api extraction
             var apiResources = apiTemplateResources.Where(resource => resource.type == ResourceTypeConstants.API);

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/AuthorizationServerExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/AuthorizationServerExtractor.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateAuthorizationServersARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl)
+        public async Task<Template> GenerateAuthorizationServersARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl, string policyXMLSasToken)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting authorization servers from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
 
             List<TemplateResource> templateResources = new List<TemplateResource>();
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/BackendExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/BackendExtractor.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateBackendsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, List<TemplateResource> propertyResources, string policyXMLBaseUrl)
+        public async Task<Template> GenerateBackendsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, List<TemplateResource> propertyResources, string policyXMLBaseUrl, string policyXMLSasToken)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting backends from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
 
             List<TemplateResource> templateResources = new List<TemplateResource>();
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/EntityExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/EntityExtractor.cs
@@ -35,10 +35,18 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return armTemplate;
         }
 
-        public Template GenerateEmptyTemplateWithParameters(string policyXMLBaseUrl)
+        public Template GenerateEmptyTemplateWithParameters(string policyXMLBaseUrl, string policyXMLSasToken)
         {
             Template armTemplate = GenerateEmptyTemplate();
             armTemplate.parameters = new Dictionary<string, TemplateParameterProperties> { { "ApimServiceName", new TemplateParameterProperties() { type = "string" } } };
+            if (policyXMLBaseUrl != null && policyXMLSasToken != null)
+            {
+                TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "string"
+                };
+                armTemplate.parameters.Add("PolicyXMLSasToken", policyTemplateSasTokenParameterProperties);
+            }
             if (policyXMLBaseUrl != null)
             {
                 TemplateParameterProperties policyTemplateBaseUrlParameterProperties = new TemplateParameterProperties()

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateLoggerTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl)
+        public async Task<Template> GenerateLoggerTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl, string policyXMLSasToken)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting loggers from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
 
             // isolate product api associations in the case of a single api extraction
             var diagnosticResources = apiTemplateResources.Where(resource => resource.type == ResourceTypeConstants.APIDiagnostic);

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PolicyExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PolicyExtractor.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateGlobalServicePolicyTemplateAsync(string apimname, string resourceGroup, string policyXMLBaseUrl, string fileFolder)
+        public async Task<Template> GenerateGlobalServicePolicyTemplateAsync(string apimname, string resourceGroup, string policyXMLBaseUrl, string policyXMLSasToken, string fileFolder)
         {
             // extract global service policy in both full and single api extraction cases
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting global service policy from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
 
             List<TemplateResource> templateResources = new List<TemplateResource>();
 
@@ -54,7 +54,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     this.fileWriter.CreateFolderIfNotExists(policyFolder);
                     this.fileWriter.WriteXMLToFile(policyXMLContent, String.Concat(policyFolder, globalServicePolicyFileName));
                     globalServicePolicyResource.properties.format = "rawxml-link";
-                    globalServicePolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{globalServicePolicyFileName}')]";
+                    if (policyXMLSasToken != null)
+                    {
+                        globalServicePolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{globalServicePolicyFileName}', parameters('PolicyXMLSasToken'))]";
+                    }
+                    else
+                    {
+                        globalServicePolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{globalServicePolicyFileName}')]";
+                    }
                 }
 
                 templateResources.Add(globalServicePolicyResource);

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductExtractor.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
         
-        public async Task<Template> GenerateProductsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl, string fileFolder)
+        public async Task<Template> GenerateProductsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl, string policyXMLSasToken, string fileFolder)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting products from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
 
             // isolate product api associations in the case of a single api extraction
             var productAPIResources = apiTemplateResources.Where(resource => resource.type == ResourceTypeConstants.ProductAPI);
@@ -134,7 +134,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                             this.fileWriter.CreateFolderIfNotExists(policyFolder);
                             this.fileWriter.WriteXMLToFile(policyXMLContent, String.Concat(policyFolder, productPolicyFileName));
                             productPolicyResource.properties.format = "rawxml-link";
-                            productPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{productPolicyFileName}')]";
+                            if (policyXMLSasToken != null)
+                            {
+                                productPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{productPolicyFileName}', parameters('PolicyXMLSasToken'))]";
+                            }
+                            else
+                            {
+                                productPolicyResource.properties.value = $"[concat(parameters('PolicyXMLBaseUrl'), '{productPolicyFileName}')]";
+                            }
                         }
 
                         templateResources.Add(productPolicyResource);

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PropertyExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PropertyExtractor.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateNamedValuesTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl)
+        public async Task<Template> GenerateNamedValuesTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl, string policyXMLSasToken)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting named values from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
 
             List<TemplateResource> templateResources = new List<TemplateResource>();
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagExtractor.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateTagsTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, List<TemplateResource> productTemplateResources, string policyXMLBaseUrl)
+        public async Task<Template> GenerateTagsTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, List<TemplateResource> productTemplateResources, string policyXMLBaseUrl, string policyXMLSasToken)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting tags from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl);
+            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
 
             // isolate tag and api operation associations in the case of a single api extraction
             var apiOperationTagResources = apiTemplateResources.Where(resource => resource.type == ResourceTypeConstants.APIOperationTag);

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/ExtractorUtils.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/ExtractorUtils.cs
@@ -57,30 +57,32 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             string resourceGroup = exc.resourceGroup;
             string destinationApim = exc.destinationApimName;
             string linkedBaseUrl = exc.linkedTemplatesBaseUrl;
+            string linkedSasToken = exc.linkedTemplatesSasToken;
             string policyXMLBaseUrl = exc.policyXMLBaseUrl;
+            string policyXMLSasToken = exc.policyXMLSasToken;
             string dirName = exc.fileFolder;
             List<string> multipleApiNames = multipleAPINames;
             string linkedUrlQueryString = exc.linkedTemplatesUrlQueryString;
 
             // extract templates from apim service
-            Template globalServicePolicyTemplate = await policyExtractor.GenerateGlobalServicePolicyTemplateAsync(sourceApim, resourceGroup, policyXMLBaseUrl, dirName);
+            Template globalServicePolicyTemplate = await policyExtractor.GenerateGlobalServicePolicyTemplateAsync(sourceApim, resourceGroup, policyXMLBaseUrl, policyXMLSasToken, dirName);
             if (apiTemplate == null)
             {
-                apiTemplate = await apiExtractor.GenerateAPIsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, multipleApiNames, policyXMLBaseUrl, dirName);
+                apiTemplate = await apiExtractor.GenerateAPIsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, multipleApiNames, policyXMLBaseUrl, policyXMLSasToken, dirName);
             }
             List<TemplateResource> apiTemplateResources = apiTemplate.resources.ToList();
-            Template apiVersionSetTemplate = await apiVersionSetExtractor.GenerateAPIVersionSetsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl);
-            Template authorizationServerTemplate = await authorizationServerExtractor.GenerateAuthorizationServersARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl);
-            Template loggerTemplate = await loggerExtractor.GenerateLoggerTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl);
-            Template productTemplate = await productExtractor.GenerateProductsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, dirName);
+            Template apiVersionSetTemplate = await apiVersionSetExtractor.GenerateAPIVersionSetsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, policyXMLSasToken);
+            Template authorizationServerTemplate = await authorizationServerExtractor.GenerateAuthorizationServersARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, policyXMLSasToken);
+            Template loggerTemplate = await loggerExtractor.GenerateLoggerTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, policyXMLSasToken);
+            Template productTemplate = await productExtractor.GenerateProductsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, policyXMLSasToken, dirName);
             List<TemplateResource> productTemplateResources = productTemplate.resources.ToList();
-            Template namedValueTemplate = await propertyExtractor.GenerateNamedValuesTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl);
-            Template tagTemplate = await tagExtractor.GenerateTagsTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, productTemplateResources, policyXMLBaseUrl);
+            Template namedValueTemplate = await propertyExtractor.GenerateNamedValuesTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, policyXMLSasToken);
+            Template tagTemplate = await tagExtractor.GenerateTagsTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, productTemplateResources, policyXMLBaseUrl, policyXMLSasToken);
             List<TemplateResource> namedValueResources = namedValueTemplate.resources.ToList();
-            Template backendTemplate = await backendExtractor.GenerateBackendsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, namedValueResources, policyXMLBaseUrl);
+            Template backendTemplate = await backendExtractor.GenerateBackendsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, namedValueResources, policyXMLBaseUrl, policyXMLSasToken);
 
             // create parameters file
-            Template templateParameters = masterTemplateExtractor.CreateMasterTemplateParameterValues(destinationApim, linkedBaseUrl, linkedUrlQueryString, policyXMLBaseUrl);
+            Template templateParameters = masterTemplateExtractor.CreateMasterTemplateParameterValues(destinationApim, linkedBaseUrl, linkedSasToken, linkedUrlQueryString, policyXMLBaseUrl, policyXMLSasToken);
 
             // write templates to output file location
             string apiFileName = fileNameGenerator.GenerateExtractorAPIFileName(singleApiName, sourceApim);
@@ -124,7 +126,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 Template masterTemplate = masterTemplateExtractor.GenerateLinkedMasterTemplate(
                     apiTemplate, globalServicePolicyTemplate, apiVersionSetTemplate, productTemplate,
                     loggerTemplate, backendTemplate, authorizationServerTemplate, namedValueTemplate,
-                    tagTemplate, fileNames, apiFileName, linkedUrlQueryString, policyXMLBaseUrl);
+                    tagTemplate, fileNames, apiFileName, linkedUrlQueryString, linkedSasToken, policyXMLBaseUrl, policyXMLSasToken);
 
                 fileWriter.WriteJSONToFile(masterTemplate, String.Concat(@dirName, fileNames.linkedMaster));
             }


### PR DESCRIPTION
Hi

This change adds support for specifying SAS Tokens to use when deploying the ARM templates.  For example if you specify a linkedTemplatesBaseUrl that points to Azure Storage you can also specify the SAS Token to use when the ARM deployment task is accessing that storage.  SAS Tokens are specified separately for the linkedTemplatesBaseUrl and the policyXMLBaseUrl.  

Support is provided by adding two new parameters that can be specified in the extractorparams.json config file.
  1. linkedTemplatesSasToken (SAS Token for use with linkedTemplatesBaseUrl)
  2. policyXMLSasToken (SAS Token for use with policyXMLBaseUrl)

In my own use I just enter them in to config file with either dummy data or an empty string e.g.

    "linkedTemplatesSasToken": "place_holder",
    "policyXMLSasToken": "place_holder",
 
or

    "linkedTemplatesSasToken": "",
    "policyXMLSasToken": "",
 
This way the Sas Tokens are not stored in my templates but the parameters are still created so I can use the parameter override feature of Azure DevOps ARM Deployment Tasks to replace these with real tokens when the pipeline runs.

This addresses issue #321 

Thanks

Alan