### PR TITLE
[Extractor] Handle non-valid json as an operation sample without throwing an exception

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
 using System.Linq;
+using System.Threading.Tasks;
+using apimtemplate.Extractor.Utilities;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 {
@@ -786,7 +787,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
         private static void ArmEscapeSampleValueIfNecessary(OperationTemplateRepresentation operationTemplateRepresentation)
         {
-            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType == "application/json" && JToken.Parse(operationTemplateRepresentation.sample).Type == JTokenType.Array)
+            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType == "application/json" && operationTemplateRepresentation.sample.TryParseJson(out JToken sampleAsJToken) && sampleAsJToken.Type == JTokenType.Array)
             {
                 operationTemplateRepresentation.sample = "[" + operationTemplateRepresentation.sample;
             }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -787,7 +787,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
         private static void ArmEscapeSampleValueIfNecessary(OperationTemplateRepresentation operationTemplateRepresentation)
         {
-            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType == "application/json" && operationTemplateRepresentation.sample.TryParseJson(out JToken sampleAsJToken) && sampleAsJToken.Type == JTokenType.Array)
+            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType?.Contains("application/json", StringComparison.OrdinalIgnoreCase) == true && operationTemplateRepresentation.sample.TryParseJson(out JToken sampleAsJToken) && sampleAsJToken.Type == JTokenType.Array)
             {
                 operationTemplateRepresentation.sample = "[" + operationTemplateRepresentation.sample;
             }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/StringExtensions.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/StringExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace apimtemplate.Extractor.Utilities
+{
+    static class StringExtensions
+    {
+        internal static bool TryParseJson(this string str, out JToken result)
+        {
+            try
+            {
+                result = JToken.Parse(str);
+                return true;
+            }
+            catch (Exception)
+            {
+                
+            }
+
+            result = null;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes a minor bug introduced in #242 where I took for granted that operation samples with content type application/json were valid json.