### PR TITLE
fixed issue with using paramServiceUrl

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -408,11 +408,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 foreach (string apiName in apisToExtract)
                 {
                     string validApiName = ExtractorUtils.GenValidParamName(apiName, "Api");
-                    string serviceUrl = GetApiServiceUrlFromParameters(apiName, exc.serviceUrlParameters);
-                    if (serviceUrl == null)
-                    {
-                        serviceUrl = await apiExc.GetAPIServiceUrl(exc.sourceApimName, exc.resourceGroup, apiName);
-                    }
+                    string serviceUrl = exc.serviceUrlParameters != null ? GetApiServiceUrlFromParameters(apiName, exc.serviceUrlParameters) :
+                      await apiExc.GetAPIServiceUrl(exc.sourceApimName, exc.resourceGroup, apiName);
                     serviceUrls.Add(validApiName, serviceUrl);
                 }
                 TemplateServiceUrlProperties serviceUrlProperties = new TemplateServiceUrlProperties()


### PR DESCRIPTION
if serviceUrlParameters is not set when paramServiceUrl is true, then user will get error below:

`Extracting backends from service
'xxxxxxxxxxapi' Backend found
Error occured: Object reference not set to an instance of an object.
Object reference not set to an instance of an object.`

fix will handle when serviceUrlParameters is null