### PR TITLE
[Creator] productgroup generated arm fix

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductGroupTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductGroupTemplateCreator.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{productName}/{groupName}')]",
                 type = ResourceTypeConstants.ProductGroup,
                 apiVersion = GlobalConstants.APIVersion,
-                dependsOn = dependsOn
+                dependsOn = dependsOn,
+                properties=new ProductGroupTemplateProperties()
             };
             return productAPITemplateResource;
         }


### PR DESCRIPTION
the ARM template generated for Product Groups was malformed 
"Invalid payload format.  Contract should have 'properties' specified."

adding properties with default value fixed the problem

sorry for the PR without enough testings
