### PR TITLE
Added Named Values support for Creator

### DIFF
--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -26,6 +26,7 @@ The utility requires one argument, --configFile, which points to a yaml file tha
 | apiVersionSets         | Array<[APIVersionSetConfiguration](#APIVersionSetConfiguration)> | No               | List of API Version Set configurations.                        |
 | apis                   | Array<[APIConfiguration](#APIConfiguration)>      | Yes                   | List of API configurations.                                |
 | products                   | Array<[ProductConfiguration](#ProductConfiguration)>      | No                   | List of Product configurations.                                |
+| namedValues               | Array<[PropertyConfiguration](#PropertyConfiguration)>     | No                   | List of Named Values
 | loggers                   | Array<[LoggerConfiguration](#LoggerConfiguration)>      | No                   | List of Logger configurations.                                |
 | authorizationServers                   | Array<[AuthorizationServerContractProperties](#https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service/authorizationservers#AuthorizationServerContractProperties)>      | No                   | List of Authorization Server configurations.                                |
 | backends                   | Array<[BackendContractProperties](#https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service/backends#BackendContractProperties)>      | No                   | List of Backend configurations.                                |
@@ -91,6 +92,15 @@ _Additional properties found in [ApiVersionSetContractProperties](https://docs.m
 | policy                | string                | No                    | Location of the Product policy XML file. Can be url or local file.                          |
 
 _Additional properties found in [ProductContractProperties](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service/products#ProductContractProperties)_
+
+#### PropertyConfiguration
+
+| Property              | Type                  | Required              | Value                                            |
+|-----------------------|-----------------------|-----------------------|--------------------------------------------------|
+| displayName                | string                | Yes                    | Unique name of Property. It may contain only letters, digits, period, dash, and underscore characters.                          |
+| value                | string                | Yes                    | Value of the property. Can contain policy expressions. It may not be empty or consist only of whitespace.                          |
+
+_Additional properties found in [PropertyContractProperties](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service/properties#propertycontractproperties-object)_
 
 #### LoggerConfiguration
 

--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -97,6 +97,8 @@ _Additional properties found in [ProductContractProperties](https://docs.microso
 
 | Property              | Type                  | Required              | Value                                            |
 |-----------------------|-----------------------|-----------------------|--------------------------------------------------|
+| tags                | array                | No                    | Optional tags that when provided can be used to filter the property list. - string
+| secret                | boolean                | No                    | Determines whether the value is a secret and should be encrypted or not. Default value is false.
 | displayName                | string                | Yes                    | Unique name of Property. It may contain only letters, digits, period, dash, and underscore characters.                          |
 | value                | string                | Yes                    | Value of the property. Can contain policy expressions. It may not be empty or consist only of whitespace.                          |
 

--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/MasterTemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/MasterTemplateCreatorTests.cs
@@ -16,17 +16,18 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             Template apiVersionSetsTemplate = new Template();
             Template globalServicePolicyTemplate = new Template();
             Template productsTemplate = new Template();
+            Template propertyTemplate = new Template();
             Template tagTemplate = new Template();
             Template loggersTemplate = new Template();
             List<LinkedMasterTemplateAPIInformation> apiInfoList = new List<LinkedMasterTemplateAPIInformation>() { new LinkedMasterTemplateAPIInformation() { name = "api", isSplit = true } };
             FileNameGenerator fileNameGenerator = new FileNameGenerator();
             FileNames creatorFileNames = fileNameGenerator.GenerateFileNames(creatorConfig.apimServiceName);
 
-            // should create 7 resources (globalServicePolicy, apiVersionSet, product, tag, logger, both api templates)
-            int count = 7;
+            // should create 7 resources (globalServicePolicy, apiVersionSet, product, property, tag, logger, both api templates)
+            int count = 8;
 
             // act
-            Template masterTemplate = masterTemplateCreator.CreateLinkedMasterTemplate(creatorConfig, globalServicePolicyTemplate, apiVersionSetsTemplate, productsTemplate, loggersTemplate, null, null, tagTemplate, apiInfoList, creatorFileNames, creatorConfig.apimServiceName, fileNameGenerator);
+            Template masterTemplate = masterTemplateCreator.CreateLinkedMasterTemplate(creatorConfig, globalServicePolicyTemplate, apiVersionSetsTemplate, productsTemplate, propertyTemplate, loggersTemplate, null, null, tagTemplate, apiInfoList, creatorFileNames, creatorConfig.apimServiceName, fileNameGenerator);
 
             // assert
             Assert.Equal(count, masterTemplate.resources.Length);

--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/PropertyTemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/PropertyTemplateCreatorTests.cs
@@ -1,0 +1,33 @@
+using Xunit;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
+{
+    public class PropertyTemplateCreatorTests
+    {
+        [Fact]
+        public void ShouldCreatePropertyFromCreatorConfig()
+        {
+            // arrange
+            PropertyTemplateCreator propertyTemplateCreator = new PropertyTemplateCreator();
+            CreatorConfig creatorConfig = new CreatorConfig() { namedValues = new List<PropertyConfig>() };
+            PropertyConfig property = new PropertyConfig()
+            {
+                displayName = "displayName",
+                value = "value"
+            };
+            creatorConfig.namedValues.Add(property);
+
+            // act
+            Template propertyTemplate = propertyTemplateCreator.CreatePropertyTemplate(creatorConfig);
+            PropertyTemplateResource propertyTemplateResource = (PropertyTemplateResource)propertyTemplate.resources[0];
+
+            // assert
+            Assert.Equal($"[concat(parameters('ApimServiceName'), '/{property.displayName}')]", propertyTemplateResource.name);
+            Assert.Equal(property.displayName, propertyTemplateResource.properties.displayName);
+            Assert.Equal(property.value, propertyTemplateResource.properties.value);
+        }
+    }
+}

--- a/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     DiagnosticTemplateCreator diagnosticTemplateCreator = new DiagnosticTemplateCreator();
                     ReleaseTemplateCreator releaseTemplateCreator = new ReleaseTemplateCreator();
                     ProductTemplateCreator productTemplateCreator = new ProductTemplateCreator(policyTemplateCreator, productGroupTemplateCreator);
+                    PropertyTemplateCreator propertyTemplateCreator = new PropertyTemplateCreator();
                     TagTemplateCreator tagTemplateCreator = new TagTemplateCreator();
                     APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, productAPITemplateCreator, tagAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
                     MasterTemplateCreator masterTemplateCreator = new MasterTemplateCreator();
@@ -62,6 +63,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     Console.WriteLine("Creating product template");
                     Console.WriteLine("------------------------------------------");
                     Template productsTemplate = creatorConfig.products != null ? productTemplateCreator.CreateProductTemplate(creatorConfig) : null;
+                    Console.WriteLine("Creating named values template");
+                    Console.WriteLine("------------------------------------------");
+                    Template propertyTemplate = creatorConfig.namedValues != null ? propertyTemplateCreator.CreatePropertyTemplate(creatorConfig) : null;
                     Console.WriteLine("Creating logger template");
                     Console.WriteLine("------------------------------------------");
                     Template loggersTemplate = creatorConfig.loggers != null ? loggerTemplateCreator.CreateLoggerTemplate(creatorConfig) : null;
@@ -108,7 +112,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     if (creatorConfig.linked == true)
                     {
                         // create linked master template
-                        Template masterTemplate = masterTemplateCreator.CreateLinkedMasterTemplate(creatorConfig, globalServicePolicyTemplate, apiVersionSetsTemplate, productsTemplate, loggersTemplate, backendsTemplate, authorizationServersTemplate, tagTemplate, apiInformation, fileNames, creatorConfig.apimServiceName, fileNameGenerator);
+                        Template masterTemplate = masterTemplateCreator.CreateLinkedMasterTemplate(creatorConfig, globalServicePolicyTemplate, apiVersionSetsTemplate, productsTemplate, propertyTemplate, loggersTemplate, backendsTemplate, authorizationServersTemplate, tagTemplate, apiInformation, fileNames, creatorConfig.apimServiceName, fileNameGenerator);
                         fileWriter.WriteJSONToFile(masterTemplate, String.Concat(creatorConfig.outputLocation, fileNames.linkedMaster));
                     }
                     foreach (Template apiTemplate in apiTemplates)
@@ -130,6 +134,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     if (productsTemplate != null)
                     {
                         fileWriter.WriteJSONToFile(productsTemplate, String.Concat(creatorConfig.outputLocation, fileNames.products));
+                    }
+                    if (propertyTemplate != null)
+                    {
+                        fileWriter.WriteJSONToFile(propertyTemplate, String.Concat(creatorConfig.outputLocation, fileNames.namedValues));
                     }
                     if (loggersTemplate != null)
                     {

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/ExampleFiles/YAMLConfigs/valid.yml
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/ExampleFiles/YAMLConfigs/valid.yml
@@ -73,6 +73,11 @@ products:
       subscriptionsLimit: 1
       state: notPublished
       policy: C:\Users\myUsername\Projects\azure-api-management-devops-example\src\APIM_ARMTemplate\apimtemplate\Creator\ExampleFile\XMLPolicies\productSetBodyBasic.xml
+namedValues:
+    - displayName: Test
+      value: Item 1
+    - displayname: Test2
+      value: Item 2
 loggers:
     - name: myAppInsights
       loggerType: applicationInsights

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/Models/CreatorConfiguration.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/Models/CreatorConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
         public List<APIVersionSetConfig> apiVersionSets { get; set; }
         public List<APIConfig> apis { get; set; }
         public List<ProductConfig> products { get; set; }
+        public List<PropertyConfig> namedValues {get;set;}
         public List<LoggerConfig> loggers { get; set; }
         public List<AuthorizationServerTemplateProperties> authorizationServers { get; set; }
         public List<BackendTemplateProperties> backends { get; set; }
@@ -86,6 +87,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
         public string policy { get; set; }
         // coma separated names
         public string groups { get; set; }
+    }
+
+    public class PropertyConfig : PropertyResourceProperties
+    {
+
     }
     
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/MasterTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/MasterTemplateCreator.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             Template globalServicePolicyTemplate,
             Template apiVersionSetTemplate,
             Template productsTemplate,
+            Template propertyTemplate,
             Template loggersTemplate,
             Template backendsTemplate,
             Template authorizationServersTemplate,
@@ -47,6 +48,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             {
                 string productsUri = GenerateLinkedTemplateUri(creatorConfig, fileNames.products);
                 resources.Add(this.CreateLinkedMasterTemplateResource("productsTemplate", productsUri, new string[] { }));
+            }
+
+            // property
+            if (propertyTemplate != null)
+            {
+                string propertyUri = GenerateLinkedTemplateUri(creatorConfig, fileNames.namedValues);
+                resources.Add(this.CreateLinkedMasterTemplateResource("propertyTemplate", propertyUri, new string[] { }));
             }
 
             // logger

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PropertyTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PropertyTemplateCreator.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     properties = new PropertyResourceProperties()
                     {
                         displayName = namedValue.displayName,
-                        value = namedValue.value
+                        value = namedValue.value,
+                        secret = namedValue.secret,
+                        tags = namedValue.tags
                     },
                     dependsOn = new string[] {}
                 };

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PropertyTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PropertyTemplateCreator.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
+{
+    public class PropertyTemplateCreator : TemplateCreator
+    {
+        public Template CreatePropertyTemplate(CreatorConfig creatorConfig)
+        {
+            // create empty template
+            Template propertyTemplate = CreateEmptyTemplate();
+
+            // add parameters
+            propertyTemplate.parameters = new Dictionary<string, TemplateParameterProperties>
+            {
+                { ParameterNames.ApimServiceName, new TemplateParameterProperties(){ type = "string" } }
+            };
+
+            List<TemplateResource> resources = new List<TemplateResource>();
+            foreach (PropertyConfig namedValue in creatorConfig.namedValues)
+            {
+                // create property resource with properties
+                PropertyTemplateResource propertyTemplateResource = new PropertyTemplateResource()
+                {
+                    name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{namedValue.displayName}')]",
+                    type = ResourceTypeConstants.Property,
+                    apiVersion = GlobalConstants.APIVersion,
+                    properties = new PropertyResourceProperties()
+                    {
+                        displayName = namedValue.displayName,
+                        value = namedValue.value
+                    },
+                    dependsOn = new string[] {}
+                };
+                resources.Add(propertyTemplateResource);
+            }
+
+            propertyTemplate.resources = resources.ToArray();
+            return propertyTemplate;
+        }
+    }
+}

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/Utilities/CreatorConfigurationValidator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/Utilities/CreatorConfigurationValidator.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             {
                 return false;
             }
+            if (ValidateNamedValues(creatorConfig) != true)
+            {
+                return false;
+            }
             if (ValidateLoggers(creatorConfig) != true)
             {
                 return false;
@@ -48,6 +52,22 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             return true;
         }
 
+        public bool ValidateNamedValues(CreatorConfig creatorConfig)
+        {
+            bool isValid = true;
+            if (creatorConfig.namedValues != null)
+            {
+                foreach (PropertyResourceProperties property in creatorConfig.namedValues)
+                {
+                    if (property.displayName == null)
+                    {
+                        isValid = false;
+                        throw new CommandParsingException(commandLineApplication, "Display name is required is a Named Value is provided");
+                    }
+                }
+            }
+            return isValid;
+        }
         public bool ValidateProducts(CreatorConfig creatorConfig)
         {
             bool isValid = true;


### PR DESCRIPTION
Added support for Named Values within the yaml config files used by the Creator.

Followed definition in [Microsoft Docs](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service/properties) and reused elements from the extractor when possible.

I added and updated tests for the Properties and I have validated that I was able to deploy multiple defined Named Values with some being secrets and having tags.