### PR TITLE
Package Creator and Extractor as a dotnet CLI tool.

### DIFF
--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -285,6 +285,17 @@ Below are the steps to run the Creator from the source code:
 
 You can also run it directly from the [releases](https://github.com/Azure/azure-api-management-devops-resource-kit/releases).
 
+Additionaly, the Creator can also be made available as a global [dotnet CLI tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools) in your Azure DevOps artifacts or private NuGet repository. Build the Creator, and run the following commands to package the Creator as a dotnet tool:
+
+```
+dotnet pack -c Release
+dotnet tool install -g --add-source .\bin\Release apimtemplate
+```
+
+The Creator tool is now available anywhere on the command-line:
+
+```apim-templates create --configFile CONFIG_YAML_FILE_LOCATION ```
+
 # Extractor
 
 This utility generates [Resource Manager templates](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates) by extracting existing configurations of one or more APIs in an API Management instance. 
@@ -485,3 +496,9 @@ dotnet run extract
 
 
 You can also run it directly from the [releases](https://github.com/Azure/azure-api-management-devops-resource-kit/releases).
+
+Likewise, if you [package the Extractor as a dotnet CLI tool](#creator2), you can run it from anywhere on the command-line:
+
+```
+apim-templates extract
+```

--- a/src/APIM_ARMTemplate/apimtemplate/apimtemplate.csproj
+++ b/src/APIM_ARMTemplate/apimtemplate/apimtemplate.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <ProjectGuid>{B5183465-2BC1-4206-9C9F-5AC9615AC941}</ProjectGuid>
     <LangVersion>preview</LangVersion>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>apim-templates</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Makes it possible to upload the `Creator` and `Extractor` command-line utility to a NuGet feed in Azure DevOps by packaging it as a dotnet CLI tool.