### PR TITLE
Supports naming product resources

### DIFF
--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -89,6 +89,7 @@ _Additional properties found in [ApiVersionSetContractProperties](https://docs.m
 
 | Property              | Type                  | Required              | Value                                            |
 |-----------------------|-----------------------|-----------------------|--------------------------------------------------|
+| name                | string                | No                    | Name of the product resource. If omitted, the display name is used.                          |
 | policy                | string                | No                    | Location of the Product policy XML file. Can be url or local file.                          |
 
 _Additional properties found in [ProductContractProperties](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service/products#ProductContractProperties)_
@@ -206,7 +207,8 @@ apis:
               bytes: 512
         enableHttpCorrelationHeaders: true
 products:
-    - displayName: platinum
+    - name: platinum
+      displayName: Platinum
       description: a test product
       terms: some terms
       subscriptionRequired: true

--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/ProductTemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/ProductTemplateCreatorTests.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             CreatorConfig creatorConfig = new CreatorConfig() { products = new List<ProductConfig>() };
             ProductConfig product = new ProductConfig()
             {
-                displayName = "displayName",
+                name = "name",
+                displayName = "display name",
                 description = "description",
                 terms = "terms",
                 subscriptionRequired = true,
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             ProductsTemplateResource productsTemplateResource = (ProductsTemplateResource)productTemplate.resources[0];
 
             // assert
-            Assert.Equal($"[concat(parameters('ApimServiceName'), '/{product.displayName}')]", productsTemplateResource.name);
+            Assert.Equal($"[concat(parameters('ApimServiceName'), '/{product.name}')]", productsTemplateResource.name);
             Assert.Equal(product.displayName, productsTemplateResource.properties.displayName);
             Assert.Equal(product.description, productsTemplateResource.properties.description);
             Assert.Equal(product.terms, productsTemplateResource.properties.terms);
@@ -63,7 +64,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             ProductsTemplateResource productsTemplateResource = (ProductsTemplateResource)productTemplate.resources[0];
 
             // assert
-            Assert.Equal($"[concat(parameters('ApimServiceName'), '/{product.displayName}')]", productsTemplateResource.name);
+            Assert.Equal($"[concat(parameters('ApimServiceName'), '/{product.name}')]", productsTemplateResource.name);
             Assert.Equal(product.displayName, productsTemplateResource.properties.displayName);
             Assert.Equal(product.description, productsTemplateResource.properties.description);
             Assert.Equal(product.terms, productsTemplateResource.properties.terms);

--- a/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/ProductsTemplateResource.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/ProductsTemplateResource.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
 
     public class ProductsTemplateProperties
     {
+        public string name { get; set; }
         public string description { get; set; }
         public string terms { get; set; }
         public bool subscriptionRequired { get; set; }

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductTemplateCreator.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
         private PolicyTemplateCreator policyTemplateCreator;
         private ProductGroupTemplateCreator productGroupTemplateCreator;
 
-        public ProductTemplateCreator(PolicyTemplateCreator policyTemplateCreator,ProductGroupTemplateCreator productGroupTemplateCreator)
+        public ProductTemplateCreator(PolicyTemplateCreator policyTemplateCreator, ProductGroupTemplateCreator productGroupTemplateCreator)
         {
             this.policyTemplateCreator = policyTemplateCreator;
             this.productGroupTemplateCreator = productGroupTemplateCreator;
@@ -28,10 +28,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             List<TemplateResource> resources = new List<TemplateResource>();
             foreach (ProductConfig product in creatorConfig.products)
             {
+                if (string.IsNullOrEmpty(product.name))
+                    product.name = product.displayName;
+
                 // create product resource with properties
                 ProductsTemplateResource productsTemplateResource = new ProductsTemplateResource()
                 {
-                    name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{product.displayName}')]",
+                    name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{product.name}')]",
                     type = ResourceTypeConstants.Product,
                     apiVersion = GlobalConstants.APIVersion,
                     properties = new ProductsTemplateProperties()
@@ -57,7 +60,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 }
 
                 // create product group resources if provided
-                if(product.groups != null)
+                if (product.groups != null)
                 {
                     string[] dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products', parameters('{ParameterNames.ApimServiceName}'), '{product.displayName}')]" };
                     List<ProductGroupsValue> productGroups = this.productGroupTemplateCreator.CreateProductGroupTemplateResources(product, dependsOn);


### PR DESCRIPTION
A product resources’s `displayName` property is required. 

Nonetheless, it is designed to be a user-friendly name and may include spaces or other characters that are not otherwise allowed in an ARM resource.

This PR fixes #385 and supports an additionnal `name` property.
If not specified, the ARM resource name would default to the product `displayName` as is currently the case.