### PR TITLE
Correct spelling of apiVersionSets property

### DIFF
--- a/example/demo/Input/valid.yml
+++ b/example/demo/Input/valid.yml
@@ -1,6 +1,6 @@
 version: 0.0.1   # Required
 apimServiceName: contosoapim-dev   # Required, must match name of an apim service deployed in the specified resource group
-apiVersionSet:   # Optional
+apiVersionSets:   # Optional
   - id: myVersionSetID
     displayName: myAPIVersionSet
     description: a description
@@ -14,7 +14,7 @@ apis:
     policy: ./Input/apiPolicyHeaders.xml   # Optional, can be url or local file
     suffix: myAPIPet   # Required
     apiVersion: v1   # Optional
-    apiVersionDescription: My first version   # Optional 
+    apiVersionDescription: My first version   # Optional
     apiVersionSetId: myVersionSetID
     revision: 1   # Optional
     revisionDescription: My first revision   # Optional


### PR DESCRIPTION
I lost a couple of hours figuring out how to make the demo work.

The problem was that when I ran the templates i got back:
```
New-AzResourceGroupDeployment : 14:13:21 - Resource Microsoft.ApiManagement/service/apis '.../myAPI' failed with message '{
  "error": {
    "code": "ResourceNotFound",
    "message": "ApiVersionSet not found.",
    "details": null
  }
}
```
After digging around I found out that the apiVersionSets.template.json-file did not get generated, and while debugging i found that the `apiVersionSets`-property was null because it was spelled `apiVersionSet` in the valid.yml-file.