### PR TITLE
Product Group and Policy resources should use the product name if present

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PolicyTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PolicyTemplateCreator.cs
@@ -74,12 +74,15 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 
         public PolicyTemplateResource CreateProductPolicyTemplateResource(ProductConfig product, string[] dependsOn)
         {
+            if (string.IsNullOrEmpty(product.name))
+                product.name = product.displayName;
+
             Uri uriResult;
             bool isUrl = Uri.TryCreate(product.policy, UriKind.Absolute, out uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
             // create policy resource with properties
             PolicyTemplateResource policyTemplateResource = new PolicyTemplateResource()
             {
-                name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{product.displayName}/policy')]",
+                name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{product.name}/policy')]",
                 type = ResourceTypeConstants.ProductPolicy,
                 apiVersion = GlobalConstants.APIVersion,
                 properties = new PolicyTemplateProperties()

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductGroupTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductGroupTemplateCreator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             string[] groupNames = product.groups.Split(", ");
             foreach (string groupName in groupNames)
             {
-                ProductGroupsValue productAPITemplate = this.CreateProductGroupTemplateResource(groupName, product.displayName, dependsOn);
+                ProductGroupsValue productAPITemplate = this.CreateProductGroupTemplateResource(groupName, product.name, dependsOn);
                 productGroupTemplates.Add(productAPITemplate);
             }
             return productGroupTemplates;

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductTemplateCreator.cs
@@ -28,9 +28,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             List<TemplateResource> resources = new List<TemplateResource>();
             foreach (ProductConfig product in creatorConfig.products)
             {
-                if (string.IsNullOrEmpty(product.name))
-                    product.name = product.displayName;
-
                 // create product resource with properties
                 ProductsTemplateResource productsTemplateResource = new ProductsTemplateResource()
                 {
@@ -54,7 +51,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 // create product policy resource that depends on the product, if provided
                 if (product.policy != null)
                 {
-                    string[] dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products', parameters('{ParameterNames.ApimServiceName}'), '{product.displayName}')]" };
+                    string[] dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products', parameters('{ParameterNames.ApimServiceName}'), '{product.name}')]" };
                     PolicyTemplateResource productPolicy = this.policyTemplateCreator.CreateProductPolicyTemplateResource(product, dependsOn);
                     resources.Add(productPolicy);
                 }
@@ -62,7 +59,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 // create product group resources if provided
                 if (product.groups != null)
                 {
-                    string[] dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products', parameters('{ParameterNames.ApimServiceName}'), '{product.displayName}')]" };
+                    string[] dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products', parameters('{ParameterNames.ApimServiceName}'), '{product.name}')]" };
                     List<ProductGroupsValue> productGroups = this.productGroupTemplateCreator.CreateProductGroupTemplateResources(product, dependsOn);
                     resources.AddRange(productGroups);
                 }


### PR DESCRIPTION
This PR fixes #393. 

Following work on #385, this PR fixes the remaining dependent resources, when using a product `name` instead of its `displayName`.