### PR TITLE
Fix for ARM templates version generated using the creator tool is not supported error

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Common/Constants/GlobalConstants.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/Constants/GlobalConstants.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public const string ExtractDescription = "Extract an existing API Management instance";
 
         public const string APIVersion = "2019-01-01";
-        public const string LinkedAPIVersion = "2018-01-01";
+        public const string LinkedAPIVersion = "2018-05-01";
         public const int NumOfRecords = 100;
 
         public const string azAccessToken = "account get-access-token --query \"accessToken\" --output json";


### PR DESCRIPTION
### Fix for ARM templates version generated using the creator tool is not supported error

**Issue/Error:**  When using the generated ARM templates in Azure devops for deployment facing the below error.
Resource Microsoft.Resources/deployments
     | 'globalServicePolicyTemplate' failed with message '{
     | "error": {     "code": "BadRequest",     "message": "The
     | api-version '2018-01-01' is not supported for a deployment at
     | subscription scope; please use api-version '2018-05-01' or
     | later. Please see https://aka.ms/arm-deploy for usage
     | details.


**Fix suggested** - working one tested.

updating the Linked API version to working one

