### PR TITLE
Parameterizing backend Urls for the apis

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             CommandOption configFile = this.Option("--configFile <configFile>", "Config YAML file location", CommandOptionType.SingleValue).IsRequired();
 
             // list command options
-            CommandOption backendUrlFile = this.Option("--backendurlconfigFile <backendurlconfigFile>", "backend url json file location", CommandOptionType.SingleValue);
+            CommandOption backendurlconfigFile = this.Option("--backendurlconfigFile <backendurlconfigFile>", "backend url json file location", CommandOptionType.SingleValue);
 
             this.HelpOption();
 
@@ -29,9 +29,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 CreatorConfig creatorConfig = await fileReader.ConvertConfigYAMLToCreatorConfigAsync(configFile.Value());
 
                 //if backendurlfile passed as parameter
-                if (backendUrlFile != null && !string.IsNullOrEmpty(backendUrlFile.Value()))
+                if (backendurlconfigFile != null && !string.IsNullOrEmpty(backendurlconfigFile.Value()))
                 {
-                    string backendurlConfigContent = fileReader.RetrieveLocalFileContents(backendUrlFile.Value());
+                    string backendurlConfigContent = fileReader.RetrieveLocalFileContents(backendurlconfigFile.Value());
 
                     //if the file is json file
                     if (fileReader.isJSON(backendurlConfigContent))

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/ExampleFiles/BackendUrlParameter/BackendUrlParameters.json
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/ExampleFiles/BackendUrlParameter/BackendUrlParameters.json
@@ -1,0 +1,9 @@
+[{
+        "apiName": "myAPI",
+        "apiUrl": "http://myApiBackendUrl.com"
+    },
+    {
+        "apiName": "myAPI2",
+        "apiUrl": "http://myApiBackendUrl.com"
+    }
+]

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/Models/BackendUrlConfiguration.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/Models/BackendUrlConfiguration.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
+{
+    public class BackendUrlsConfig
+    {
+        public string apiName { get; set; }
+        public string apiUrl { get; set; }
+    }
+}

--- a/src/APIM_ARMTemplate/apimtemplate/apimtemplate.csproj
+++ b/src/APIM_ARMTemplate/apimtemplate/apimtemplate.csproj
@@ -7,7 +7,7 @@
     <LangVersion>preview</LangVersion>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>apim-templates</ToolCommandName>
-    <Version>1.0.1</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/APIM_ARMTemplate/apimtemplate/apimtemplate.csproj
+++ b/src/APIM_ARMTemplate/apimtemplate/apimtemplate.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,6 +7,7 @@
     <LangVersion>preview</LangVersion>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>apim-templates</ToolCommandName>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Parameterizing backend Urls for the Apis

Key value pair like - apiName
and the value will be - apiUrl.

This structure:
```
    {
        "apiName": "myAPI",
        "apiUrl": "http://myApiBackendUrl.com"
    }

```
Each _apiUrl_ value in the input json file (passed in the parameter --backendurlconfigFile) will be mapped to the _apiName_ which matches with the same name in the given input _valid.yml_ file.

**sample command below:**

`dotnet run create --configFile .\valid.yml --backendurlconfigFile .\BackendUrlParameters.json`
