### PR TITLE
created command options to pass appinsights name and instrumentationkey

### DIFF
--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -286,6 +286,8 @@ Below are the steps to run the Creator from the source code:
 - Navigate to {path_to_folder}/src/APIM_ARMTemplate/apimtemplate directory
 - Run the following command:
 ```dotnet run create --configFile CONFIG_YAML_FILE_LOCATION ```
+- Run the following command to pass AppinsightsName and Appinsights InstrumentationKey as an parameter:
+```dotnet run create --configFile CONFIG_YAML_FILE_LOCATION --appInsightsInstrumentationKey 45d4v88-fdfs-4b35-9232-731d82d4d1c6 --appInsightsName  myAppInsights ```
 
 You can also run it directly from the [releases](https://github.com/Azure/azure-api-management-devops-resource-kit/releases).
 

--- a/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
 using System.Collections.Generic;
 using System.Linq;
+using apimtemplate.Creator.Utilities;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 {
@@ -16,6 +17,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             // list command options
             CommandOption configFile = this.Option("--configFile <configFile>", "Config YAML file location", CommandOptionType.SingleValue).IsRequired();
 
+            CommandOption appInsightsInstrumentationKey = this.Option("--appInsightsInstrumentationKey <appInsightsInstrumentationKey>", "AppInsights intrumentationkey", CommandOptionType.SingleValue);
+
+            CommandOption appInsightsName = this.Option("--appInsightsName <appInsightsName>", "AppInsights Name", CommandOptionType.SingleValue);
+
             this.HelpOption();
 
             this.OnExecute(async () =>
@@ -23,6 +28,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 // convert config file to CreatorConfig class
                 FileReader fileReader = new FileReader();
                 CreatorConfig creatorConfig = await fileReader.ConvertConfigYAMLToCreatorConfigAsync(configFile.Value());
+
+                AppInsightsUpdater appInsightsUpdater = new AppInsightsUpdater();
+                appInsightsUpdater.UpdateAppInsightNameAndInstrumentationKey(creatorConfig, appInsightsInstrumentationKey, appInsightsName);
 
                 // validate creator config
                 CreatorConfigurationValidator creatorConfigurationValidator = new CreatorConfigurationValidator(this);

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/Models/CreatorConfiguration.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/Models/CreatorConfiguration.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 {
     public class CLICreatorArguments
     {
+        public string appInsightsInstrumentationKey { get; set; }
+        public string appInsightsName { get; set; }
         public string configFile { get; set; }
     }
 
@@ -95,5 +97,5 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
     {
 
     }
-    
+
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/Utilities/AppInsightsUpdater.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/Utilities/AppInsightsUpdater.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create;
+
+namespace apimtemplate.Creator.Utilities
+{
+    public class AppInsightsUpdater
+    {
+        public void UpdateAppInsightNameAndInstrumentationKey(
+            CreatorConfig creatorConfig, CommandOption appInsightsInstrumentationKey, CommandOption appInsightsName)
+        {
+            string appInsightNamePassed = string.Empty;
+
+            if(appInsightsName != null && !string.IsNullOrEmpty(appInsightsName.Value()))
+            {
+                appInsightNamePassed = appInsightsName.Value();
+                foreach (APIConfig aPIConfig in creatorConfig.apis)
+                {
+                    if(aPIConfig.diagnostic != null)
+                    {
+                        aPIConfig.diagnostic.loggerId = appInsightNamePassed;
+                    }
+                }
+            }
+
+            if (appInsightsInstrumentationKey != null && !string.IsNullOrEmpty(appInsightsInstrumentationKey.Value()))
+            {
+                string appInsightsInstrumentationKeyPassed = appInsightsInstrumentationKey.Value();
+                if(creatorConfig.loggers != null && creatorConfig.loggers.Count > 0)
+                {
+                    if (!string.IsNullOrEmpty(appInsightNamePassed))
+                    {
+                        creatorConfig.loggers[0].name = appInsightNamePassed;
+                    }
+                    if(creatorConfig.loggers[0].credentials != null)
+                    {
+                        creatorConfig.loggers[0].credentials.instrumentationKey = appInsightsInstrumentationKeyPassed;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### created command options to pass appinsights name and instrumentationkey in the command line.

Similarly parameterized the backendurls in this request #413 

Now we can pass the backendurls and the appinsights name and instrumentation key as an cli parameter with different values based on environments to the creator tool in Pipeline, solving the issue #378