### PR TITLE
Update APITemplateCreator.cs to fix the backendURL config

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -224,6 +224,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 apiTemplateResource.properties.format = format;
                 apiTemplateResource.properties.value = value;
                 apiTemplateResource.properties.path = api.suffix;
+                apiTemplateResource.properties.serviceUrl = api.serviceUrl;
+               
             }
             return apiTemplateResource;
         }


### PR DESCRIPTION
I guess there is a bug during the creation of individual arm file per Api. Only with this new line I as able to create/update APIM for new APIs with the backendURL correctly set.