### PR TITLE
upgrade to dotnet core 3.1

### DIFF
--- a/src/APIM_ARMTemplate/Dockerfile
+++ b/src/APIM_ARMTemplate/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+WORKDIR /app    
+
+# Copy csproj and restore as distinct layers
+COPY /apimtemplate/*.csproj ./
+RUN dotnet restore
+
+# Copy everything else and build
+COPY . ./
+WORKDIR /app/apimtemplate
+RUN dotnet publish apimtemplate.sln -c Release -o out
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+WORKDIR /
+COPY --from=build-env /app/apimtemplate/out .

--- a/src/APIM_ARMTemplate/apimtemplate.test/apimtemplate.test.csproj
+++ b/src/APIM_ARMTemplate/apimtemplate.test/apimtemplate.test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/APIM_ARMTemplate/apimtemplate/apimtemplate.csproj
+++ b/src/APIM_ARMTemplate/apimtemplate/apimtemplate.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ProjectGuid>{B5183465-2BC1-4206-9C9F-5AC9615AC941}</ProjectGuid>
     <LangVersion>preview</LangVersion>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
upgraded the project to dotnet core 3.1
added a docker file to package the tool so that developers can use it without requiring dotnet 3.1 as a dependency