### PR TITLE
Issue #392 Adding serviceUrl and ApiLoggerId parameters to the -apis.template when linkedTemplatesBaseUrl and includeAllRevisions are set

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -483,7 +483,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         public async Task<Template> GenerateAPIRevisionTemplateAsync(string currentRevision, List<string> revList, string apiName, Extractor exc)
         {
             // generate apiTemplate
-            Template armTemplate = GenerateEmptyTemplateWithParameters(exc.policyXMLBaseUrl, exc.policyXMLSasToken);
+            Template armTemplate = GenerateEmptyApiTemplateWithParameters(exc);
             List<TemplateResource> templateResources = new List<TemplateResource>();
             Console.WriteLine("{0} APIs found ...", revList.Count().ToString());
 


### PR DESCRIPTION
This addresses https://github.com/Azure/azure-api-management-devops-resource-kit/issues/392

The generated the -`apis.template.json` file will now correctly declare the serviceUrl and apiLoggerId parameters.