### PR TITLE
WIP - Fix for concurrency issues in #340

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorFactories/APITemplateCreatorFactory.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorFactories/APITemplateCreatorFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             DiagnosticTemplateCreator diagnosticTemplateCreator = new DiagnosticTemplateCreator();
             ReleaseTemplateCreator releaseTemplateCreator = new ReleaseTemplateCreator();
             TagAPITemplateCreator tagAPITemplateCreator = new TagAPITemplateCreator();
-            APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, productAPITemplateCreator, tagAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
+            APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, tagAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
             return apiTemplateCreator;
         }
     }

--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/MasterTemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/MasterTemplateCreatorTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             Template apiVersionSetsTemplate = new Template();
             Template globalServicePolicyTemplate = new Template();
             Template productsTemplate = new Template();
+            Template productAPIsTemplate = new Template();
             Template propertyTemplate = new Template();
             Template tagTemplate = new Template();
             Template loggersTemplate = new Template();
@@ -23,11 +24,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             FileNameGenerator fileNameGenerator = new FileNameGenerator();
             FileNames creatorFileNames = fileNameGenerator.GenerateFileNames(creatorConfig.apimServiceName);
 
-            // should create 7 resources (globalServicePolicy, apiVersionSet, product, property, tag, logger, both api templates)
-            int count = 8;
+            // should create 8 resources (globalServicePolicy, apiVersionSet, product, productAPI, property, tag, logger, both api templates)
+            int count = 9;
 
             // act
-            Template masterTemplate = masterTemplateCreator.CreateLinkedMasterTemplate(creatorConfig, globalServicePolicyTemplate, apiVersionSetsTemplate, productsTemplate, propertyTemplate, loggersTemplate, null, null, tagTemplate, apiInfoList, creatorFileNames, creatorConfig.apimServiceName, fileNameGenerator);
+            Template masterTemplate = masterTemplateCreator.CreateLinkedMasterTemplate(creatorConfig, globalServicePolicyTemplate, apiVersionSetsTemplate, productsTemplate, productAPIsTemplate, propertyTemplate, loggersTemplate, null, null, tagTemplate, apiInfoList, creatorFileNames, creatorConfig.apimServiceName, fileNameGenerator);
 
             // assert
             Assert.Equal(count, masterTemplate.resources.Length);

--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/ProductAPITemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/ProductAPITemplateCreatorTests.cs
@@ -8,6 +8,64 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
     public class ProductAPITemplateCreatorTests
     {
         [Fact]
+        public void ShouldCreateProductAPIFromCreatorConfig()
+        {
+            // arrange
+            ProductAPITemplateCreator productAPITemplateCreator = new ProductAPITemplateCreator();
+            CreatorConfig creatorConfig = new CreatorConfig() { products = new List<ProductConfig>(), apis = new List<APIConfig>() };
+            ProductConfig product = new ProductConfig()
+            {
+                name = "productName",
+                displayName = "display name",
+                description = "description",
+                terms = "terms",
+                subscriptionRequired = true,
+                approvalRequired = true,
+                subscriptionsLimit = 1,
+                state = "state"
+            };
+            creatorConfig.products.Add(product);
+            APIConfig api = new APIConfig()
+            {
+                name = "apiName",
+                apiVersion = "apiVersion",
+                apiVersionDescription = "apiVersionDescription",
+                apiVersionSetId = "apiVersionSetId",
+                apiRevision = "revision",
+                apiRevisionDescription = "revisionDescription",
+                suffix = "suffix",
+                products = "productName",
+                subscriptionRequired = true,
+                authenticationSettings = new APITemplateAuthenticationSettings()
+                {
+                    oAuth2 = new APITemplateOAuth2()
+                    {
+                        authorizationServerId = "",
+                        scope = ""
+                    },
+                    openid = new APITemplateOpenID()
+                    {
+                        openidProviderId = "",
+                        bearerTokenSendingMethods = new string[] { }
+                    },
+                    subscriptionKeyRequired = true
+                },
+                openApiSpec = "https://petstore.swagger.io/v2/swagger.json",
+                protocols = "https",
+                isCurrent = true,
+                type = "http"
+            };
+            creatorConfig.apis.Add(api);
+
+            // act
+            Template productAPITemplate = productAPITemplateCreator.CreateProductAPITemplate(creatorConfig);
+            ProductAPITemplateResource productAPITemplateResource = (ProductAPITemplateResource)productAPITemplate.resources[0];
+
+            // assert
+            Assert.Equal($"[concat(parameters('ApimServiceName'), '/{product.name}/{api.name}')]", productAPITemplateResource.name);
+        }
+
+        [Fact]
         public void ShouldCreateProductAPITemplateResourceFromValues()
         {
             // arrange

--- a/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     ProductTemplateCreator productTemplateCreator = new ProductTemplateCreator(policyTemplateCreator, productGroupTemplateCreator);
                     PropertyTemplateCreator propertyTemplateCreator = new PropertyTemplateCreator();
                     TagTemplateCreator tagTemplateCreator = new TagTemplateCreator();
-                    APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, productAPITemplateCreator, tagAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
+                    APITemplateCreator apiTemplateCreator = new APITemplateCreator(fileReader, policyTemplateCreator, tagAPITemplateCreator, diagnosticTemplateCreator, releaseTemplateCreator);
                     MasterTemplateCreator masterTemplateCreator = new MasterTemplateCreator();
 
                     // create templates from provided configuration
@@ -84,6 +84,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     Console.WriteLine("Creating product template");
                     Console.WriteLine("------------------------------------------");
                     Template productsTemplate = creatorConfig.products != null ? productTemplateCreator.CreateProductTemplate(creatorConfig) : null;
+                    Console.WriteLine("Creating product/APIs template");
+                    Console.WriteLine("------------------------------------------");
+                    Template productAPIsTemplate = (creatorConfig.products != null && creatorConfig.apis != null) ? productAPITemplateCreator.CreateProductAPITemplate(creatorConfig) : null;
                     Console.WriteLine("Creating named values template");
                     Console.WriteLine("------------------------------------------");
                     Template propertyTemplate = creatorConfig.namedValues != null ? propertyTemplateCreator.CreatePropertyTemplate(creatorConfig) : null;
@@ -133,7 +136,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     if (creatorConfig.linked == true)
                     {
                         // create linked master template
-                        Template masterTemplate = masterTemplateCreator.CreateLinkedMasterTemplate(creatorConfig, globalServicePolicyTemplate, apiVersionSetsTemplate, productsTemplate, propertyTemplate, loggersTemplate, backendsTemplate, authorizationServersTemplate, tagTemplate, apiInformation, fileNames, creatorConfig.apimServiceName, fileNameGenerator);
+                        Template masterTemplate = masterTemplateCreator.CreateLinkedMasterTemplate(creatorConfig, globalServicePolicyTemplate, apiVersionSetsTemplate, productsTemplate, productAPIsTemplate, propertyTemplate, loggersTemplate, backendsTemplate, authorizationServersTemplate, tagTemplate, apiInformation, fileNames, creatorConfig.apimServiceName, fileNameGenerator);
                         fileWriter.WriteJSONToFile(masterTemplate, String.Concat(creatorConfig.outputLocation, fileNames.linkedMaster));
                     }
                     foreach (Template apiTemplate in apiTemplates)
@@ -155,6 +158,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     if (productsTemplate != null)
                     {
                         fileWriter.WriteJSONToFile(productsTemplate, String.Concat(creatorConfig.outputLocation, fileNames.products));
+                    }
+                    if (productAPIsTemplate != null)
+                    {
+                        fileWriter.WriteJSONToFile(productAPIsTemplate, String.Concat(creatorConfig.outputLocation, fileNames.productAPIs));
                     }
                     if (propertyTemplate != null)
                     {

--- a/src/APIM_ARMTemplate/apimtemplate/Common/FileHandlers/FileNameGenerator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/FileHandlers/FileNameGenerator.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
                 tags = $@"/{baseFileName}tags.template.json",
                 products = $@"/{baseFileName}products.template.json",
                 productAPIs = $@"/{baseFileName}productAPIs.template.json",
+                apiTags = $@"/{baseFileName}apiTags.template.json",
                 parameters = $@"/{baseFileName}parameters.json",
                 linkedMaster = $@"/{baseFileName}master.template.json",
                 apis = "/Apis",
@@ -72,6 +73,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public string tags { get; set; }
         public string products { get; set; }
         public string productAPIs { get; set; }
+        public string apiTags { get; set; }
         public string parameters { get; set; }
         // linked property outputs 1 master template
         public string linkedMaster { get; set; }

--- a/src/APIM_ARMTemplate/apimtemplate/Common/FileHandlers/FileNameGenerator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/FileHandlers/FileNameGenerator.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
                 namedValues = $@"/{baseFileName}namedValues.template.json",
                 tags = $@"/{baseFileName}tags.template.json",
                 products = $@"/{baseFileName}products.template.json",
+                productAPIs = $@"/{baseFileName}productAPIs.template.json",
                 parameters = $@"/{baseFileName}parameters.json",
                 linkedMaster = $@"/{baseFileName}master.template.json",
                 apis = "/Apis",
@@ -70,6 +71,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public string namedValues { get; set; }
         public string tags { get; set; }
         public string products { get; set; }
+        public string productAPIs { get; set; }
         public string parameters { get; set; }
         // linked property outputs 1 master template
         public string linkedMaster { get; set; }

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -11,16 +11,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
     {
         private FileReader fileReader;
         private PolicyTemplateCreator policyTemplateCreator;
-        private ProductAPITemplateCreator productAPITemplateCreator;
         private TagAPITemplateCreator tagAPITemplateCreator;
         private DiagnosticTemplateCreator diagnosticTemplateCreator;
         private ReleaseTemplateCreator releaseTemplateCreator;
 
-        public APITemplateCreator(FileReader fileReader, PolicyTemplateCreator policyTemplateCreator, ProductAPITemplateCreator productAPITemplateCreator, TagAPITemplateCreator tagAPITemplateCreator, DiagnosticTemplateCreator diagnosticTemplateCreator, ReleaseTemplateCreator releaseTemplateCreator)
+        public APITemplateCreator(FileReader fileReader, PolicyTemplateCreator policyTemplateCreator, TagAPITemplateCreator tagAPITemplateCreator, DiagnosticTemplateCreator diagnosticTemplateCreator, ReleaseTemplateCreator releaseTemplateCreator)
         {
             this.fileReader = fileReader;
             this.policyTemplateCreator = policyTemplateCreator;
-            this.productAPITemplateCreator = productAPITemplateCreator;
             this.tagAPITemplateCreator = tagAPITemplateCreator;
             this.diagnosticTemplateCreator = diagnosticTemplateCreator;
             this.releaseTemplateCreator = releaseTemplateCreator;
@@ -90,7 +88,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 
             PolicyTemplateResource apiPolicyResource = api.policy != null ? this.policyTemplateCreator.CreateAPIPolicyTemplateResource(api, dependsOn) : null;
             List<PolicyTemplateResource> operationPolicyResources = api.operations != null ? this.policyTemplateCreator.CreateOperationPolicyTemplateResources(api, dependsOn) : null;
-            List<ProductAPITemplateResource> productAPIResources = api.products != null ? this.productAPITemplateCreator.CreateProductAPITemplateResources(api, dependsOn) : null;
             List<TagAPITemplateResource> tagAPIResources = api.tags != null ? this.tagAPITemplateCreator.CreateTagAPITemplateResources(api,dependsOn) : null;
             DiagnosticTemplateResource diagnosticTemplateResource = api.diagnostic != null ? this.diagnosticTemplateCreator.CreateAPIDiagnosticTemplateResource(api, dependsOn) : null;
             // add release resource if the name has been appended with ;rev{revisionNumber}
@@ -99,7 +96,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             // add resources if not null
             if (apiPolicyResource != null) resources.Add(apiPolicyResource);
             if (operationPolicyResources != null) resources.AddRange(operationPolicyResources);
-            if (productAPIResources != null) resources.AddRange(productAPIResources);
             if (tagAPIResources != null) resources.AddRange(tagAPIResources);
             if (diagnosticTemplateResource != null) resources.Add(diagnosticTemplateResource);
             if (releaseTemplateResource != null) resources.Add(releaseTemplateResource);

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductAPITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductAPITemplateCreator.cs
@@ -22,8 +22,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             {
                 List<ProductAPITemplateResource> apiResources = CreateProductAPITemplateResources(api, dependsOn);
                 resources.AddRange(apiResources);                
+
                 // Add previous product/API resource as a dependency for next product/API resource(s)
-                dependsOn = new string[] { apiResources[apiResources.Count-1].name };
+                string productID = apiResources[apiResources.Count-1].name.Split('/', 3)[1];
+                dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{productID}', '{api.name}')]" };
             }
 
             productTemplate.resources = resources.ToArray();

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -417,33 +417,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             }
             catch (Exception) { }
 
-            // add product api associations to template
-            #region API Products
-            try
-            {
-                // pull product api associations
-                string apiProducts = await GetAPIProductsAsync(apimname, resourceGroup, apiName);
-                JObject oApiProducts = JObject.Parse(apiProducts);
-
-                foreach (var item in oApiProducts["value"])
-                {
-                    string apiProductName = ((JValue)item["name"]).Value.ToString();
-                    Console.WriteLine("'{0}' Product association found", apiProductName);
-
-                    // convert returned api product associations to template resource class
-                    ProductAPITemplateResource productAPIResource = JsonConvert.DeserializeObject<ProductAPITemplateResource>(item.ToString());
-                    productAPIResource.type = ResourceTypeConstants.ProductAPI;
-                    productAPIResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiProductName}/{oApiName}')]";
-                    productAPIResource.apiVersion = GlobalConstants.APIVersion;
-                    productAPIResource.scale = null;
-                    productAPIResource.dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{oApiName}')]" };
-
-                    templateResources.Add(productAPIResource);
-                }
-            }
-            catch (Exception) { }
-            #endregion
-
             #region Diagnostics
             // add diagnostics to template
             // pull diagnostics for api

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             this.fileWriter = fileWriter;
         }
 
-        private async Task<string[]> GetAllOperationNames(string ApiManagementName, string ResourceGroupName, string ApiName)
+        public async Task<string[]> GetAllOperationNames(string ApiManagementName, string ResourceGroupName, string ApiName)
         {
             JObject oOperations = new JObject();
             int numOfOps = 0;

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -332,30 +332,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     templateResources.Add(operationPolicyResource);
                 }
                 catch (Exception) { }
-
-
-                // add tags associated with the operation to template 
-                try
-                {
-                    // pull tags associated with the operation
-                    string apiOperationTags = await GetOperationTagsAsync(apimname, resourceGroup, oApiName, operationName);
-                    JObject oApiOperationTags = JObject.Parse(apiOperationTags);
-
-                    foreach (var tag in oApiOperationTags["value"])
-                    {
-                        string apiOperationTagName = ((JValue)tag["name"]).Value.ToString();
-                        Console.WriteLine(" - '{0}' Tag association found for {1} operation", apiOperationTagName, operationResourceName);
-
-                        // convert operation tag association to template resource class
-                        TagTemplateResource operationTagResource = JsonConvert.DeserializeObject<TagTemplateResource>(tag.ToString());
-                        operationTagResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{oApiName}/{operationResourceName}/{apiOperationTagName}')]";
-                        operationTagResource.apiVersion = GlobalConstants.APIVersion;
-                        operationTagResource.scale = null;
-                        operationTagResource.dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis/operations', parameters('{ParameterNames.ApimServiceName}'), '{oApiName}', '{operationResourceName}')]" };
-                        templateResources.Add(operationTagResource);
-                    }
-                }
-                catch (Exception) { }
             }
             #endregion
 
@@ -393,29 +369,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             }
             catch (Exception) { }
             #endregion
-
-            // add tags associated with the api to template 
-            try
-            {
-                // pull tags associated with the api
-                string apiTags = await GetAPITagsAsync(apimname, resourceGroup, apiName);
-                JObject oApiTags = JObject.Parse(apiTags);
-
-                foreach (var tag in oApiTags["value"])
-                {
-                    string apiTagName = ((JValue)tag["name"]).Value.ToString();
-                    Console.WriteLine("'{0}' Tag association found", apiTagName);
-
-                    // convert associations between api and tags to template resource class
-                    TagTemplateResource apiTagResource = JsonConvert.DeserializeObject<TagTemplateResource>(tag.ToString());
-                    apiTagResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{oApiName}/{apiTagName}')]";
-                    apiTagResource.apiVersion = GlobalConstants.APIVersion;
-                    apiTagResource.scale = null;
-                    apiTagResource.dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{oApiName}')]" };
-                    templateResources.Add(apiTagResource);
-                }
-            }
-            catch (Exception) { }
 
             #region Diagnostics
             // add diagnostics to template

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             Template globalServicePolicyTemplate,
             Template apiVersionSetTemplate,
             Template productsTemplate,
+            Template productAPIsTemplate,
             Template loggersTemplate,
             Template backendsTemplate,
             Template authorizationServersTemplate,
@@ -41,6 +42,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
             // api dependsOn
             List<string> apiDependsOn = new List<string>();
+            List<string> productAPIDependsOn = new List<string>();
 
             if (namedValuesTemplate != null && namedValuesTemplate.resources.Count() != 0)
             {
@@ -70,6 +72,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             if (productsTemplate != null && productsTemplate.resources.Count() != 0)
             {
                 apiDependsOn.Add("[resourceId('Microsoft.Resources/deployments', 'productsTemplate')]");
+                productAPIDependsOn.Add("[resourceId('Microsoft.Resources/deployments', 'productsTemplate')]");
                 string productsUri = GenerateLinkedTemplateUri(exc.linkedTemplatesUrlQueryString, exc.linkedTemplatesSasToken, fileNames.products);
                 resources.Add(this.CreateLinkedMasterTemplateResourceWithPolicyToken("productsTemplate", productsUri, dependsOnNamedValues, exc));
             }
@@ -108,8 +111,16 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             // api
             if (apiTemplate != null && apiTemplate.resources.Count() != 0)
             {
+                productAPIDependsOn.Add("[resourceId('Microsoft.Resources/deployments', 'apisTemplate')]");
                 string apisUri = GenerateLinkedTemplateUri(exc.linkedTemplatesUrlQueryString, exc.linkedTemplatesSasToken, apiFileName);
                 resources.Add(this.CreateLinkedMasterTemplateResourceForApiTemplate("apisTemplate", apisUri, apiDependsOn.ToArray(), exc));
+            }
+
+            // productAPIs
+            if (productAPIsTemplate != null && productAPIsTemplate.resources.Count() != 0)
+            {
+                string productAPIsUri = GenerateLinkedTemplateUri(exc.linkedTemplatesUrlQueryString, exc.linkedTemplatesSasToken, fileNames.productAPIs);
+                resources.Add(this.CreateLinkedMasterTemplateResourceWithPolicyToken("productAPIsTemplate", productAPIsUri, productAPIDependsOn.ToArray(), exc));
             }
             Console.WriteLine("Master template generated");
             masterTemplate.resources = resources.ToArray();

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             Template apiVersionSetTemplate,
             Template productsTemplate,
             Template productAPIsTemplate,
+            Template apiTagsTemplate,
             Template loggersTemplate,
             Template backendsTemplate,
             Template authorizationServersTemplate,
@@ -43,6 +44,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             // api dependsOn
             List<string> apiDependsOn = new List<string>();
             List<string> productAPIDependsOn = new List<string>();
+            List<string> apiTagDependsOn = new List<string>();
 
             if (namedValuesTemplate != null && namedValuesTemplate.resources.Count() != 0)
             {
@@ -79,6 +81,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
             if (tagTemplate != null && tagTemplate.resources.Count() != 0)
             {
+                apiTagDependsOn.Add("[resourceId('Microsoft.Resources/deployments', 'tagTemplate')]");
                 apiDependsOn.Add("[resourceId('Microsoft.Resources/deployments', 'tagTemplate')]");
                 string tagUri = GenerateLinkedTemplateUri(exc.linkedTemplatesUrlQueryString, exc.linkedTemplatesSasToken, fileNames.tags);
                 resources.Add(this.CreateLinkedMasterTemplateResourceWithPolicyToken("tagTemplate", tagUri, dependsOnNamedValues, exc));
@@ -111,6 +114,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             // api
             if (apiTemplate != null && apiTemplate.resources.Count() != 0)
             {
+                apiTagDependsOn.Add("[resourceId('Microsoft.Resources/deployments', 'apisTemplate')]");
                 productAPIDependsOn.Add("[resourceId('Microsoft.Resources/deployments', 'apisTemplate')]");
                 string apisUri = GenerateLinkedTemplateUri(exc.linkedTemplatesUrlQueryString, exc.linkedTemplatesSasToken, apiFileName);
                 resources.Add(this.CreateLinkedMasterTemplateResourceForApiTemplate("apisTemplate", apisUri, apiDependsOn.ToArray(), exc));
@@ -121,6 +125,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             {
                 string productAPIsUri = GenerateLinkedTemplateUri(exc.linkedTemplatesUrlQueryString, exc.linkedTemplatesSasToken, fileNames.productAPIs);
                 resources.Add(this.CreateLinkedMasterTemplateResourceWithPolicyToken("productAPIsTemplate", productAPIsUri, productAPIDependsOn.ToArray(), exc));
+            }
+
+            // apiTags
+            if (apiTagsTemplate != null && apiTagsTemplate.resources.Count() != 0)
+            {
+                string apiTagsUri = GenerateLinkedTemplateUri(exc.linkedTemplatesUrlQueryString, exc.linkedTemplatesSasToken, fileNames.apiTags);
+                resources.Add(this.CreateLinkedMasterTemplateResourceWithPolicyToken("apiTagsTemplate", apiTagsUri, apiTagDependsOn.ToArray(), exc));
             }
             Console.WriteLine("Master template generated");
             masterTemplate.resources = resources.ToArray();

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
@@ -1,0 +1,436 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using apimtemplate.Extractor.Utilities;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
+{
+    public class ProductAPIExtractor : EntityExtractor
+    {
+        private FileWriter fileWriter;
+
+        public ProductAPIExtractor(FileWriter fileWriter)
+        {
+            this.fileWriter = fileWriter;
+        }
+
+        private async Task<string[]> GetAllOperationNames(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            JObject oOperations = new JObject();
+            int numOfOps = 0;
+            List<string> operationNames = new List<string>();
+            do
+            {
+                (string azToken, string azSubId) = await auth.GetAccessToken();
+
+                string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations?$skip={5}&api-version={6}",
+                   baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, numOfOps, GlobalConstants.APIVersion);
+                numOfOps += GlobalConstants.NumOfRecords;
+
+                string operations = await CallApiManagementAsync(azToken, requestUrl);
+
+                oOperations = JObject.Parse(operations);
+
+                foreach (var item in oOperations["value"])
+                {
+                    operationNames.Add(((JValue)item["name"]).Value.ToString());
+                }
+            }
+            while (oOperations["nextLink"] != null);
+            return operationNames.ToArray();
+        }
+
+        public async Task<string> GetAPIOperationDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}?api-version={6}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetOperationPolicyAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}/policies/policy?api-version={6}&format=rawxml",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetOperationTagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}/tags?api-version={6}&format=rawxml",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPIServiceUrl(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            string apiDetails = await CallApiManagementAsync(azToken, requestUrl);
+            JObject oApiDetails = JObject.Parse(apiDetails);
+            APITemplateResource apiResource = JsonConvert.DeserializeObject<APITemplateResource>(apiDetails);
+            return apiResource.properties.serviceUrl;
+        }
+
+        public async Task<string> GetAPIDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<JToken[]> GetAllAPIObjsAsync(string ApiManagementName, string ResourceGroupName)
+        {
+            JObject oApi = new JObject();
+            int numOfApis = 0;
+            List<JToken> apiObjs = new List<JToken>();
+            do
+            {
+                (string azToken, string azSubId) = await auth.GetAccessToken();
+
+                string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?$skip={4}&api-version={5}",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, numOfApis, GlobalConstants.APIVersion);
+                numOfApis += GlobalConstants.NumOfRecords;
+
+                string apis = await CallApiManagementAsync(azToken, requestUrl);
+
+                oApi = JObject.Parse(apis);
+
+                foreach (var item in oApi["value"])
+                {
+                    apiObjs.Add(item);
+                }
+            }
+            while (oApi["nextLink"] != null);
+            return apiObjs.ToArray();
+        }
+
+        public async Task<List<string>> GetAllAPINamesAsync(string ApiManagementName, string ResourceGroupName)
+        {
+            JToken[] oApis = await GetAllAPIObjsAsync(ApiManagementName, ResourceGroupName);
+            List<string> apiNames = new List<string>();
+
+            foreach (JToken curApi in oApis)
+            {
+                string apiName = ((JValue)curApi["name"]).Value.ToString();
+                apiNames.Add(apiName);
+            }
+            return apiNames;
+        }
+
+        public async Task<string> GetAPIChangeLogAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/releases?api-version={5}",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPIRevisionsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/revisions?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPIPolicyAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/policies/policy?api-version={5}&format=rawxml",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPITagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/tags?api-version={5}",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+        public async Task<string> GetAPIDiagnosticsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/diagnostics?api-version={5}",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPIProductsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/products?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPISchemasAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/schemas?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPISchemaDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string schemaName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/schemas/{5}?api-version={6}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, schemaName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<List<TemplateResource>> GenerateSingleProductAPIResourceAsync(string apiName, Extractor exc, string[] dependsOn)
+        {
+            List<TemplateResource> templateResources = new List<TemplateResource>();
+            string apimname = exc.sourceApimName, resourceGroup = exc.resourceGroup, fileFolder = exc.fileFolder, policyXMLBaseUrl = exc.policyXMLBaseUrl, policyXMLSasToken = exc.policyXMLSasToken;
+
+            Console.WriteLine("------------------------------------------");
+            Console.WriteLine("Extracting products from {0} API:", apiName);
+
+            // add product api associations to template
+            #region API Products
+            try
+            {
+                // pull product api associations
+                string apiProducts = await GetAPIProductsAsync(apimname, resourceGroup, apiName);
+                JObject oApiProducts = JObject.Parse(apiProducts);
+
+                string lastProductAPIName = null;
+
+                foreach (var item in oApiProducts["value"])
+                {
+                    string apiProductName = ((JValue)item["name"]).Value.ToString();
+                    Console.WriteLine("'{0}' Product association found", apiProductName);
+
+                    // convert returned api product associations to template resource class
+                    ProductAPITemplateResource productAPIResource = JsonConvert.DeserializeObject<ProductAPITemplateResource>(item.ToString());
+                    productAPIResource.type = ResourceTypeConstants.ProductAPI;
+                    productAPIResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiProductName}/{apiName}')]";
+                    productAPIResource.apiVersion = GlobalConstants.APIVersion;
+                    productAPIResource.scale = null;
+                    productAPIResource.dependsOn = (lastProductAPIName != null) ? new string[] { lastProductAPIName } : dependsOn;
+
+                    templateResources.Add(productAPIResource);
+
+                    lastProductAPIName = $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiProductName}', '{apiName}')]";
+                }
+            }
+            catch (Exception) { }
+            #endregion
+
+            return templateResources;
+        }
+
+        // this function generate apiTemplate for single api with all its revisions
+        public async Task<Template> GenerateProductAPIRevisionTemplateAsync(string currentRevision, List<string> revList, string apiName, Extractor exc, string[] dependsOn)
+        {
+            // generate apiTemplate
+            Template armTemplate = GenerateEmptyTemplateWithParameters(exc.policyXMLBaseUrl, exc.policyXMLSasToken);
+            List<TemplateResource> templateResources = new List<TemplateResource>();
+            Console.WriteLine("{0} APIs found ...", revList.Count().ToString());
+
+            List<TemplateResource> apiResources = await GenerateSingleProductAPIResourceAsync(apiName, exc, dependsOn);
+            templateResources.AddRange(apiResources);
+
+            string lastProductAPIName = null;
+
+            foreach (string curApi in revList)
+            {
+                // add current API revision resource to template
+                apiResources = await GenerateSingleProductAPIResourceAsync(curApi, exc, (lastProductAPIName != null ? new string[] { lastProductAPIName } : dependsOn));
+                templateResources.AddRange(apiResources);
+
+                // Extract the product name from the last resource
+                string apiProductName = apiResources.Last().name.Split('/', 3)[1];
+                lastProductAPIName = $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiProductName}', '{apiName}')]";
+            }
+
+            armTemplate.resources = templateResources.ToArray();
+            return armTemplate;
+        }
+
+        public async Task<Template> GenerateAPIProductsARMTemplateAsync(string singleApiName, List<string> multipleApiNames, Extractor exc)
+        {
+            // initialize arm template
+            Template armTemplate = GenerateEmptyApiTemplateWithParameters(exc);
+            List<TemplateResource> templateResources = new List<TemplateResource>();
+            // when extract single API
+            if (singleApiName != null)
+            {
+                // check if this api exist
+                try
+                {
+                    string apiDetails = await GetAPIDetailsAsync(exc.sourceApimName, exc.resourceGroup, singleApiName);
+                    Console.WriteLine("{0} API found ...", singleApiName);
+                    templateResources.AddRange(await GenerateSingleProductAPIResourceAsync(singleApiName, exc, new string[] {}));
+                }
+                catch (Exception)
+                {
+                    throw new Exception($"{singleApiName} API not found!");
+                }
+            }
+            // when extract multiple APIs and generate one master template
+            else if (multipleApiNames != null)
+            {
+                Console.WriteLine("{0} APIs found ...", multipleApiNames.Count().ToString());
+
+                string[] dependsOn = new string[] {};
+                foreach (string apiName in multipleApiNames)
+                {
+                    templateResources.AddRange(await GenerateSingleProductAPIResourceAsync(apiName, exc, dependsOn));
+                    string apiProductName = templateResources.Last().name.Split('/', 3)[1];
+                    dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiProductName}', '{apiName}')]" };
+                }
+            }
+            // when extract all APIs and generate one master template
+            else
+            {
+                JToken[] oApis = await GetAllAPIObjsAsync(exc.sourceApimName, exc.resourceGroup);
+                Console.WriteLine("{0} APIs found ...", (oApis.Count().ToString()));
+
+                string[] dependsOn = new string[] {};
+                foreach (JToken oApi in oApis)
+                {
+                    string apiName = ((JValue)oApi["name"]).Value.ToString();
+                    templateResources.AddRange(await GenerateSingleProductAPIResourceAsync(apiName, exc, dependsOn));
+                    string apiProductName = templateResources.Last().name.Split('/', 3)[1];
+                    dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiProductName}', '{apiName}')]" };
+                }
+            }
+            armTemplate.resources = templateResources.ToArray();
+            return armTemplate;
+        }
+
+        private static void ArmEscapeSampleValueIfNecessary(OperationTemplateRepresentation operationTemplateRepresentation)
+        {
+            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType?.Contains("application/json", StringComparison.OrdinalIgnoreCase) == true && operationTemplateRepresentation.sample.TryParseJson(out JToken sampleAsJToken) && sampleAsJToken.Type == JTokenType.Array)
+            {
+                operationTemplateRepresentation.sample = "[" + operationTemplateRepresentation.sample;
+            }
+        }
+
+        private static void AddSchemaDependencyToOperationIfNecessary(string oApiName, List<string> operationDependsOn, OperationTemplateRepresentation operationTemplateRepresentation)
+        {
+            if (operationTemplateRepresentation.schemaId != null)
+            {
+                string dependsOn = $"[resourceId('Microsoft.ApiManagement/service/apis/schemas', parameters('{ParameterNames.ApimServiceName}'), '{oApiName}', '{operationTemplateRepresentation.schemaId}')]";
+                // add value to list if schema has not already been added
+                if (!operationDependsOn.Exists(o => o == dependsOn))
+                {
+                    operationDependsOn.Add(dependsOn);
+                }
+            }
+        }
+
+        private static bool CheckAPIExist(string singleApiName, JObject oApi)
+        {
+            for (int i = 0; i < ((JContainer)oApi["value"]).Count; i++)
+            {
+                if (((JValue)oApi["value"][i]["name"]).Value.ToString().Equals(singleApiName))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private async Task<List<TemplateResource>> GenerateSchemasARMTemplate(string apimServiceName, string apiName, string resourceGroup, string fileFolder)
+        {
+            List<TemplateResource> templateResources = new List<TemplateResource>();
+
+            // pull all schemas from service
+            string schemas = await GetAPISchemasAsync(apimServiceName, resourceGroup, apiName);
+            JObject oSchemas = JObject.Parse(schemas);
+
+            foreach (var item in oSchemas["value"])
+            {
+                string schemaName = ((JValue)item["name"]).Value.ToString();
+                Console.WriteLine("'{0}' Operation schema found", schemaName);
+
+                string schemaDetails = await GetAPISchemaDetailsAsync(apimServiceName, resourceGroup, apiName, schemaName);
+
+                // pull returned schema and convert to template resource
+                RESTReturnedSchemaTemplate restReturnedSchemaTemplate = JsonConvert.DeserializeObject<RESTReturnedSchemaTemplate>(schemaDetails);
+                SchemaTemplateResource schemaDetailsResource = JsonConvert.DeserializeObject<SchemaTemplateResource>(schemaDetails);
+                schemaDetailsResource.properties.document.value = GetSchemaValueBasedOnContentType(restReturnedSchemaTemplate.properties);
+                schemaDetailsResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{schemaName}')]";
+                schemaDetailsResource.apiVersion = GlobalConstants.APIVersion;
+                schemaDetailsResource.dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
+
+                templateResources.Add(schemaDetailsResource);
+
+            }
+            return templateResources;
+        }
+
+        private string GetSchemaValueBasedOnContentType(RESTReturnedSchemaTemplateProperties schemaTemplateProperties)
+        {
+            var contentType = schemaTemplateProperties.contentType.ToLowerInvariant();
+            if (contentType.Equals("application/vnd.oai.openapi.components+json"))
+            {
+                // for OpenAPI "value" is not used, but "components" which is resolved during json deserialization
+                return null;
+            }
+
+            if (!(schemaTemplateProperties.document is JToken))
+            {
+                return JsonConvert.SerializeObject(schemaTemplateProperties.document);
+            }
+
+            var schemaJson = schemaTemplateProperties.document as JToken;
+
+            switch (contentType)
+            {
+                case "application/vnd.ms-azure-apim.swagger.definitions+json":
+                    if (schemaJson["definitions"] != null && schemaJson.Count() == 1)
+                    {
+                        schemaJson = schemaJson["definitions"];
+                    }
+                    break;
+                case "application/vnd.ms-azure-apim.xsd+xml":
+                    if (schemaJson["value"] != null && schemaJson.Count() == 1)
+                    {
+                        return schemaJson["value"].ToString();
+                    }
+                    break;
+            }
+
+            return JsonConvert.SerializeObject(schemaJson);
+        }
+    }
+}

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
@@ -18,75 +18,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             this.fileWriter = fileWriter;
         }
 
-        private async Task<string[]> GetAllOperationNames(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            JObject oOperations = new JObject();
-            int numOfOps = 0;
-            List<string> operationNames = new List<string>();
-            do
-            {
-                (string azToken, string azSubId) = await auth.GetAccessToken();
-
-                string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations?$skip={5}&api-version={6}",
-                   baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, numOfOps, GlobalConstants.APIVersion);
-                numOfOps += GlobalConstants.NumOfRecords;
-
-                string operations = await CallApiManagementAsync(azToken, requestUrl);
-
-                oOperations = JObject.Parse(operations);
-
-                foreach (var item in oOperations["value"])
-                {
-                    operationNames.Add(((JValue)item["name"]).Value.ToString());
-                }
-            }
-            while (oOperations["nextLink"] != null);
-            return operationNames.ToArray();
-        }
-
-        public async Task<string> GetAPIOperationDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}?api-version={6}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetOperationPolicyAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}/policies/policy?api-version={6}&format=rawxml",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetOperationTagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}/tags?api-version={6}&format=rawxml",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPIServiceUrl(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            string apiDetails = await CallApiManagementAsync(azToken, requestUrl);
-            JObject oApiDetails = JObject.Parse(apiDetails);
-            APITemplateResource apiResource = JsonConvert.DeserializeObject<APITemplateResource>(apiDetails);
-            return apiResource.properties.serviceUrl;
-        }
-
         public async Task<string> GetAPIDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
         {
             (string azToken, string azSubId) = await auth.GetAccessToken();
@@ -123,93 +54,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return apiObjs.ToArray();
         }
 
-        public async Task<List<string>> GetAllAPINamesAsync(string ApiManagementName, string ResourceGroupName)
-        {
-            JToken[] oApis = await GetAllAPIObjsAsync(ApiManagementName, ResourceGroupName);
-            List<string> apiNames = new List<string>();
-
-            foreach (JToken curApi in oApis)
-            {
-                string apiName = ((JValue)curApi["name"]).Value.ToString();
-                apiNames.Add(apiName);
-            }
-            return apiNames;
-        }
-
-        public async Task<string> GetAPIChangeLogAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/releases?api-version={5}",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPIRevisionsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/revisions?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPIPolicyAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/policies/policy?api-version={5}&format=rawxml",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPITagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/tags?api-version={5}",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-        public async Task<string> GetAPIDiagnosticsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/diagnostics?api-version={5}",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
         public async Task<string> GetAPIProductsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
         {
             (string azToken, string azSubId) = await auth.GetAccessToken();
 
             string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/products?api-version={5}",
                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPISchemasAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/schemas?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPISchemaDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string schemaName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/schemas/{5}?api-version={6}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, schemaName, GlobalConstants.APIVersion);
 
             return await CallApiManagementAsync(azToken, requestUrl);
         }
@@ -254,34 +104,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             #endregion
 
             return templateResources;
-        }
-
-        // this function generate apiTemplate for single api with all its revisions
-        public async Task<Template> GenerateProductAPIRevisionTemplateAsync(string currentRevision, List<string> revList, string apiName, Extractor exc, string[] dependsOn)
-        {
-            // generate apiTemplate
-            Template armTemplate = GenerateEmptyTemplateWithParameters(exc.policyXMLBaseUrl, exc.policyXMLSasToken);
-            List<TemplateResource> templateResources = new List<TemplateResource>();
-            Console.WriteLine("{0} APIs found ...", revList.Count().ToString());
-
-            List<TemplateResource> apiResources = await GenerateSingleProductAPIResourceAsync(apiName, exc, dependsOn);
-            templateResources.AddRange(apiResources);
-
-            string lastProductAPIName = null;
-
-            foreach (string curApi in revList)
-            {
-                // add current API revision resource to template
-                apiResources = await GenerateSingleProductAPIResourceAsync(curApi, exc, (lastProductAPIName != null ? new string[] { lastProductAPIName } : dependsOn));
-                templateResources.AddRange(apiResources);
-
-                // Extract the product name from the last resource
-                string apiProductName = apiResources.Last().name.Split('/', 3)[1];
-                lastProductAPIName = $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiProductName}', '{apiName}')]";
-            }
-
-            armTemplate.resources = templateResources.ToArray();
-            return armTemplate;
         }
 
         public async Task<Template> GenerateAPIProductsARMTemplateAsync(string singleApiName, List<string> multipleApiNames, Extractor exc)
@@ -334,103 +156,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             }
             armTemplate.resources = templateResources.ToArray();
             return armTemplate;
-        }
-
-        private static void ArmEscapeSampleValueIfNecessary(OperationTemplateRepresentation operationTemplateRepresentation)
-        {
-            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType?.Contains("application/json", StringComparison.OrdinalIgnoreCase) == true && operationTemplateRepresentation.sample.TryParseJson(out JToken sampleAsJToken) && sampleAsJToken.Type == JTokenType.Array)
-            {
-                operationTemplateRepresentation.sample = "[" + operationTemplateRepresentation.sample;
-            }
-        }
-
-        private static void AddSchemaDependencyToOperationIfNecessary(string oApiName, List<string> operationDependsOn, OperationTemplateRepresentation operationTemplateRepresentation)
-        {
-            if (operationTemplateRepresentation.schemaId != null)
-            {
-                string dependsOn = $"[resourceId('Microsoft.ApiManagement/service/apis/schemas', parameters('{ParameterNames.ApimServiceName}'), '{oApiName}', '{operationTemplateRepresentation.schemaId}')]";
-                // add value to list if schema has not already been added
-                if (!operationDependsOn.Exists(o => o == dependsOn))
-                {
-                    operationDependsOn.Add(dependsOn);
-                }
-            }
-        }
-
-        private static bool CheckAPIExist(string singleApiName, JObject oApi)
-        {
-            for (int i = 0; i < ((JContainer)oApi["value"]).Count; i++)
-            {
-                if (((JValue)oApi["value"][i]["name"]).Value.ToString().Equals(singleApiName))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private async Task<List<TemplateResource>> GenerateSchemasARMTemplate(string apimServiceName, string apiName, string resourceGroup, string fileFolder)
-        {
-            List<TemplateResource> templateResources = new List<TemplateResource>();
-
-            // pull all schemas from service
-            string schemas = await GetAPISchemasAsync(apimServiceName, resourceGroup, apiName);
-            JObject oSchemas = JObject.Parse(schemas);
-
-            foreach (var item in oSchemas["value"])
-            {
-                string schemaName = ((JValue)item["name"]).Value.ToString();
-                Console.WriteLine("'{0}' Operation schema found", schemaName);
-
-                string schemaDetails = await GetAPISchemaDetailsAsync(apimServiceName, resourceGroup, apiName, schemaName);
-
-                // pull returned schema and convert to template resource
-                RESTReturnedSchemaTemplate restReturnedSchemaTemplate = JsonConvert.DeserializeObject<RESTReturnedSchemaTemplate>(schemaDetails);
-                SchemaTemplateResource schemaDetailsResource = JsonConvert.DeserializeObject<SchemaTemplateResource>(schemaDetails);
-                schemaDetailsResource.properties.document.value = GetSchemaValueBasedOnContentType(restReturnedSchemaTemplate.properties);
-                schemaDetailsResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{schemaName}')]";
-                schemaDetailsResource.apiVersion = GlobalConstants.APIVersion;
-                schemaDetailsResource.dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
-
-                templateResources.Add(schemaDetailsResource);
-
-            }
-            return templateResources;
-        }
-
-        private string GetSchemaValueBasedOnContentType(RESTReturnedSchemaTemplateProperties schemaTemplateProperties)
-        {
-            var contentType = schemaTemplateProperties.contentType.ToLowerInvariant();
-            if (contentType.Equals("application/vnd.oai.openapi.components+json"))
-            {
-                // for OpenAPI "value" is not used, but "components" which is resolved during json deserialization
-                return null;
-            }
-
-            if (!(schemaTemplateProperties.document is JToken))
-            {
-                return JsonConvert.SerializeObject(schemaTemplateProperties.document);
-            }
-
-            var schemaJson = schemaTemplateProperties.document as JToken;
-
-            switch (contentType)
-            {
-                case "application/vnd.ms-azure-apim.swagger.definitions+json":
-                    if (schemaJson["definitions"] != null && schemaJson.Count() == 1)
-                    {
-                        schemaJson = schemaJson["definitions"];
-                    }
-                    break;
-                case "application/vnd.ms-azure-apim.xsd+xml":
-                    if (schemaJson["value"] != null && schemaJson.Count() == 1)
-                    {
-                        return schemaJson["value"].ToString();
-                    }
-                    break;
-            }
-
-            return JsonConvert.SerializeObject(schemaJson);
         }
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
@@ -9,59 +9,13 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 {
-    public class ProductAPIExtractor : EntityExtractor
+    public class ProductAPIExtractor : APIExtractor
     {
         private FileWriter fileWriter;
 
-        public ProductAPIExtractor(FileWriter fileWriter)
+        public ProductAPIExtractor(FileWriter fileWriter) : base (fileWriter)
         {
             this.fileWriter = fileWriter;
-        }
-
-        public async Task<string> GetAPIDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<JToken[]> GetAllAPIObjsAsync(string ApiManagementName, string ResourceGroupName)
-        {
-            JObject oApi = new JObject();
-            int numOfApis = 0;
-            List<JToken> apiObjs = new List<JToken>();
-            do
-            {
-                (string azToken, string azSubId) = await auth.GetAccessToken();
-
-                string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?$skip={4}&api-version={5}",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, numOfApis, GlobalConstants.APIVersion);
-                numOfApis += GlobalConstants.NumOfRecords;
-
-                string apis = await CallApiManagementAsync(azToken, requestUrl);
-
-                oApi = JObject.Parse(apis);
-
-                foreach (var item in oApi["value"])
-                {
-                    apiObjs.Add(item);
-                }
-            }
-            while (oApi["nextLink"] != null);
-            return apiObjs.ToArray();
-        }
-
-        public async Task<string> GetAPIProductsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/products?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
         }
 
         public async Task<List<TemplateResource>> GenerateSingleProductAPIResourceAsync(string apiName, Extractor exc, string[] dependsOn)

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
@@ -1,0 +1,505 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using apimtemplate.Extractor.Utilities;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
+{
+    public class APITagExtractor : EntityExtractor
+    {
+        private FileWriter fileWriter;
+
+        public APITagExtractor(FileWriter fileWriter)
+        {
+            this.fileWriter = fileWriter;
+        }
+
+        private async Task<string[]> GetAllOperationNames(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            JObject oOperations = new JObject();
+            int numOfOps = 0;
+            List<string> operationNames = new List<string>();
+            do
+            {
+                (string azToken, string azSubId) = await auth.GetAccessToken();
+
+                string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations?$skip={5}&api-version={6}",
+                   baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, numOfOps, GlobalConstants.APIVersion);
+                numOfOps += GlobalConstants.NumOfRecords;
+
+                string operations = await CallApiManagementAsync(azToken, requestUrl);
+
+                oOperations = JObject.Parse(operations);
+
+                foreach (var item in oOperations["value"])
+                {
+                    operationNames.Add(((JValue)item["name"]).Value.ToString());
+                }
+            }
+            while (oOperations["nextLink"] != null);
+            return operationNames.ToArray();
+        }
+
+        public async Task<string> GetAPIOperationDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}?api-version={6}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetOperationPolicyAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}/policies/policy?api-version={6}&format=rawxml",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetOperationTagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}/tags?api-version={6}&format=rawxml",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPIServiceUrl(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            string apiDetails = await CallApiManagementAsync(azToken, requestUrl);
+            JObject oApiDetails = JObject.Parse(apiDetails);
+            APITemplateResource apiResource = JsonConvert.DeserializeObject<APITemplateResource>(apiDetails);
+            return apiResource.properties.serviceUrl;
+        }
+
+        public async Task<string> GetAPIDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<JToken[]> GetAllAPIObjsAsync(string ApiManagementName, string ResourceGroupName)
+        {
+            JObject oApi = new JObject();
+            int numOfApis = 0;
+            List<JToken> apiObjs = new List<JToken>();
+            do
+            {
+                (string azToken, string azSubId) = await auth.GetAccessToken();
+
+                string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?$skip={4}&api-version={5}",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, numOfApis, GlobalConstants.APIVersion);
+                numOfApis += GlobalConstants.NumOfRecords;
+
+                string apis = await CallApiManagementAsync(azToken, requestUrl);
+
+                oApi = JObject.Parse(apis);
+
+                foreach (var item in oApi["value"])
+                {
+                    apiObjs.Add(item);
+                }
+            }
+            while (oApi["nextLink"] != null);
+            return apiObjs.ToArray();
+        }
+
+        public async Task<List<string>> GetAllAPINamesAsync(string ApiManagementName, string ResourceGroupName)
+        {
+            JToken[] oApis = await GetAllAPIObjsAsync(ApiManagementName, ResourceGroupName);
+            List<string> apiNames = new List<string>();
+
+            foreach (JToken curApi in oApis)
+            {
+                string apiName = ((JValue)curApi["name"]).Value.ToString();
+                apiNames.Add(apiName);
+            }
+            return apiNames;
+        }
+
+        public async Task<string> GetAPIChangeLogAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/releases?api-version={5}",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPIRevisionsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/revisions?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPIPolicyAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/policies/policy?api-version={5}&format=rawxml",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPITagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/tags?api-version={5}",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+        public async Task<string> GetAPIDiagnosticsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/diagnostics?api-version={5}",
+                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPIProductsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/products?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPISchemasAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/schemas?api-version={5}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<string> GetAPISchemaDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string schemaName)
+        {
+            (string azToken, string azSubId) = await auth.GetAccessToken();
+
+            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/schemas/{5}?api-version={6}",
+               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, schemaName, GlobalConstants.APIVersion);
+
+            return await CallApiManagementAsync(azToken, requestUrl);
+        }
+
+        public async Task<List<TemplateResource>> GenerateSingleAPITagResourceAsync(string apiName, Extractor exc, string[] dependsOn)
+        {
+            List<TemplateResource> templateResources = new List<TemplateResource>();
+            string apimname = exc.sourceApimName, resourceGroup = exc.resourceGroup, fileFolder = exc.fileFolder, policyXMLBaseUrl = exc.policyXMLBaseUrl, policyXMLSasToken = exc.policyXMLSasToken;
+
+            Console.WriteLine("------------------------------------------");
+            Console.WriteLine("Extracting tags from {0} API:", apiName);
+
+            string[] dependencyChain = dependsOn;
+
+            #region Operations
+
+            // pull api operations for service
+            string[] operationNames = await GetAllOperationNames(apimname, resourceGroup, apiName);
+
+            foreach (string operationName in operationNames)
+            {
+                string operationDetails = await GetAPIOperationDetailsAsync(apimname, resourceGroup, apiName, operationName);
+
+                Console.WriteLine("'{0}' Operation found", operationName);
+
+                // convert returned operation to template resource class
+                OperationTemplateResource operationResource = JsonConvert.DeserializeObject<OperationTemplateResource>(operationDetails);
+                string operationResourceName = operationResource.name;
+
+                // add tags associated with the operation to template 
+                try
+                {
+                    // pull tags associated with the operation
+                    string apiOperationTags = await GetOperationTagsAsync(apimname, resourceGroup, apiName, operationName);
+                    JObject oApiOperationTags = JObject.Parse(apiOperationTags);
+
+                    foreach (var tag in oApiOperationTags["value"])
+                    {
+                        string apiOperationTagName = ((JValue)tag["name"]).Value.ToString();
+                        Console.WriteLine(" - '{0}' Tag association found for {1} operation", apiOperationTagName, operationResourceName);
+
+                        // convert operation tag association to template resource class
+                        TagTemplateResource operationTagResource = JsonConvert.DeserializeObject<TagTemplateResource>(tag.ToString());
+                        operationTagResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{operationResourceName}/{apiOperationTagName}')]";
+                        operationTagResource.apiVersion = GlobalConstants.APIVersion;
+                        operationTagResource.scale = null;
+                        operationTagResource.dependsOn = dependencyChain;
+                        templateResources.Add(operationTagResource);
+                        dependencyChain = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis/operations/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{operationResourceName}', '{apiOperationTagName}')]" };
+                    }
+                }
+                catch (Exception) { }
+            }
+            #endregion
+
+            #region Tags
+            // add tags associated with the api to template 
+            try
+            {
+                // pull tags associated with the api
+                string apiTags = await GetAPITagsAsync(apimname, resourceGroup, apiName);
+                JObject oApiTags = JObject.Parse(apiTags);
+
+                foreach (var tag in oApiTags["value"])
+                {
+                    string apiTagName = ((JValue)tag["name"]).Value.ToString();
+                    Console.WriteLine("'{0}' Tag association found", apiTagName);
+
+                    // convert associations between api and tags to template resource class
+                    TagTemplateResource apiTagResource = JsonConvert.DeserializeObject<TagTemplateResource>(tag.ToString());
+                    apiTagResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{apiTagName}')]";
+                    apiTagResource.apiVersion = GlobalConstants.APIVersion;
+                    apiTagResource.scale = null;
+                    apiTagResource.dependsOn = dependencyChain;
+                    templateResources.Add(apiTagResource);
+                    dependencyChain = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{apiTagName}')]" };
+                }
+            }
+            catch (Exception) { }
+            #endregion
+
+            return templateResources;
+        }
+
+        // this function generate apiTemplate for single api with all its revisions
+        public async Task<Template> GenerateAPITagRevisionTemplateAsync(string currentRevision, List<string> revList, string apiName, Extractor exc, string[] dependsOn)
+        {
+            // generate apiTemplate
+            Template armTemplate = GenerateEmptyTemplateWithParameters(exc.policyXMLBaseUrl, exc.policyXMLSasToken);
+            List<TemplateResource> templateResources = new List<TemplateResource>();
+            Console.WriteLine("{0} APIs found ...", revList.Count().ToString());
+
+            List<TemplateResource> apiResources = await GenerateSingleAPITagResourceAsync(apiName, exc, dependsOn);
+            templateResources.AddRange(apiResources);
+
+            string lastAPITagName = null;
+
+            foreach (string curApi in revList)
+            {
+                // add current API revision resource to template
+                apiResources = await GenerateSingleAPITagResourceAsync(curApi, exc, (lastAPITagName != null ? new string[] { lastAPITagName } : dependsOn));
+                templateResources.AddRange(apiResources);
+
+                // Extract the tag name from the last resource
+                string[] lastTagName = apiResources.Last().name.Replace("')]", "").Split('/');
+                if (lastTagName.Length > 3)
+                {
+                    // Operations tag
+                    lastAPITagName = $"[resourceId('Microsoft.ApiManagement/service/apis/operations/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{lastTagName[2]}', '{lastTagName[3]}')]";
+                }
+                else
+                {
+                    // API tag
+                    lastAPITagName = $"[resourceId('Microsoft.ApiManagement/service/apis/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{lastTagName[2]}')]";
+                }
+            }
+
+            armTemplate.resources = templateResources.ToArray();
+            return armTemplate;
+        }
+
+        public async Task<Template> GenerateAPITagsARMTemplateAsync(string singleApiName, List<string> multipleApiNames, Extractor exc)
+        {
+            // initialize arm template
+            Template armTemplate = GenerateEmptyApiTemplateWithParameters(exc);
+            List<TemplateResource> templateResources = new List<TemplateResource>();
+            // when extract single API
+            if (singleApiName != null)
+            {
+                // check if this api exist
+                try
+                {
+                    string apiDetails = await GetAPIDetailsAsync(exc.sourceApimName, exc.resourceGroup, singleApiName);
+                    Console.WriteLine("{0} API found ...", singleApiName);
+                    templateResources.AddRange(await GenerateSingleAPITagResourceAsync(singleApiName, exc, new string[] {}));
+                }
+                catch (Exception)
+                {
+                    throw new Exception($"{singleApiName} API not found!");
+                }
+            }
+            // when extract multiple APIs and generate one master template
+            else if (multipleApiNames != null)
+            {
+                Console.WriteLine("{0} APIs found ...", multipleApiNames.Count().ToString());
+
+                string[] dependsOn = new string[] {};
+                foreach (string apiName in multipleApiNames)
+                {
+                    templateResources.AddRange(await GenerateSingleAPITagResourceAsync(apiName, exc, dependsOn));
+                    
+                    // Extract the tag name from the last resource
+                    string[] lastTagName = templateResources.Last().name.Replace("')]", "").Split('/');
+                    if (lastTagName.Length > 3)
+                    {
+                        // Operations tag
+                        dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis/operations/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{lastTagName[2]}', '{lastTagName[3]}')]" };
+                    }
+                    else
+                    {
+                        // API tag
+                        dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{lastTagName[2]}')]" };
+                    }
+                }
+            }
+            // when extract all APIs and generate one master template
+            else
+            {
+                JToken[] oApis = await GetAllAPIObjsAsync(exc.sourceApimName, exc.resourceGroup);
+                Console.WriteLine("{0} APIs found ...", (oApis.Count().ToString()));
+
+                string[] dependsOn = new string[] {};
+                foreach (JToken oApi in oApis)
+                {
+                    string apiName = ((JValue)oApi["name"]).Value.ToString();
+                    templateResources.AddRange(await GenerateSingleAPITagResourceAsync(apiName, exc, dependsOn));
+                    
+                    // Extract the tag name from the last resource
+                    string[] lastTagName = templateResources.Last().name.Replace("')]", "").Split('/');
+                    if (lastTagName.Length > 3)
+                    {
+                        // Operations tag
+                        dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis/operations/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{lastTagName[2]}', '{lastTagName[3]}')]" };
+                    }
+                    else
+                    {
+                        // API tag
+                        dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{lastTagName[2]}')]" };
+                    }
+                }
+            }
+            armTemplate.resources = templateResources.ToArray();
+            return armTemplate;
+        }
+
+        private static void ArmEscapeSampleValueIfNecessary(OperationTemplateRepresentation operationTemplateRepresentation)
+        {
+            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType?.Contains("application/json", StringComparison.OrdinalIgnoreCase) == true && operationTemplateRepresentation.sample.TryParseJson(out JToken sampleAsJToken) && sampleAsJToken.Type == JTokenType.Array)
+            {
+                operationTemplateRepresentation.sample = "[" + operationTemplateRepresentation.sample;
+            }
+        }
+
+        private static void AddSchemaDependencyToOperationIfNecessary(string oApiName, List<string> operationDependsOn, OperationTemplateRepresentation operationTemplateRepresentation)
+        {
+            if (operationTemplateRepresentation.schemaId != null)
+            {
+                string dependsOn = $"[resourceId('Microsoft.ApiManagement/service/apis/schemas', parameters('{ParameterNames.ApimServiceName}'), '{oApiName}', '{operationTemplateRepresentation.schemaId}')]";
+                // add value to list if schema has not already been added
+                if (!operationDependsOn.Exists(o => o == dependsOn))
+                {
+                    operationDependsOn.Add(dependsOn);
+                }
+            }
+        }
+
+        private static bool CheckAPIExist(string singleApiName, JObject oApi)
+        {
+            for (int i = 0; i < ((JContainer)oApi["value"]).Count; i++)
+            {
+                if (((JValue)oApi["value"][i]["name"]).Value.ToString().Equals(singleApiName))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private async Task<List<TemplateResource>> GenerateSchemasARMTemplate(string apimServiceName, string apiName, string resourceGroup, string fileFolder)
+        {
+            List<TemplateResource> templateResources = new List<TemplateResource>();
+
+            // pull all schemas from service
+            string schemas = await GetAPISchemasAsync(apimServiceName, resourceGroup, apiName);
+            JObject oSchemas = JObject.Parse(schemas);
+
+            foreach (var item in oSchemas["value"])
+            {
+                string schemaName = ((JValue)item["name"]).Value.ToString();
+                Console.WriteLine("'{0}' Operation schema found", schemaName);
+
+                string schemaDetails = await GetAPISchemaDetailsAsync(apimServiceName, resourceGroup, apiName, schemaName);
+
+                // pull returned schema and convert to template resource
+                RESTReturnedSchemaTemplate restReturnedSchemaTemplate = JsonConvert.DeserializeObject<RESTReturnedSchemaTemplate>(schemaDetails);
+                SchemaTemplateResource schemaDetailsResource = JsonConvert.DeserializeObject<SchemaTemplateResource>(schemaDetails);
+                schemaDetailsResource.properties.document.value = GetSchemaValueBasedOnContentType(restReturnedSchemaTemplate.properties);
+                schemaDetailsResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{schemaName}')]";
+                schemaDetailsResource.apiVersion = GlobalConstants.APIVersion;
+                schemaDetailsResource.dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
+
+                templateResources.Add(schemaDetailsResource);
+
+            }
+            return templateResources;
+        }
+
+        private string GetSchemaValueBasedOnContentType(RESTReturnedSchemaTemplateProperties schemaTemplateProperties)
+        {
+            var contentType = schemaTemplateProperties.contentType.ToLowerInvariant();
+            if (contentType.Equals("application/vnd.oai.openapi.components+json"))
+            {
+                // for OpenAPI "value" is not used, but "components" which is resolved during json deserialization
+                return null;
+            }
+
+            if (!(schemaTemplateProperties.document is JToken))
+            {
+                return JsonConvert.SerializeObject(schemaTemplateProperties.document);
+            }
+
+            var schemaJson = schemaTemplateProperties.document as JToken;
+
+            switch (contentType)
+            {
+                case "application/vnd.ms-azure-apim.swagger.definitions+json":
+                    if (schemaJson["definitions"] != null && schemaJson.Count() == 1)
+                    {
+                        schemaJson = schemaJson["definitions"];
+                    }
+                    break;
+                case "application/vnd.ms-azure-apim.xsd+xml":
+                    if (schemaJson["value"] != null && schemaJson.Count() == 1)
+                    {
+                        return schemaJson["value"].ToString();
+                    }
+                    break;
+            }
+
+            return JsonConvert.SerializeObject(schemaJson);
+        }
+    }
+}

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
@@ -9,107 +9,15 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 {
-    public class APITagExtractor : EntityExtractor
+    public class APITagExtractor : APIExtractor
     {
         private FileWriter fileWriter;
 
-        public APITagExtractor(FileWriter fileWriter)
+        public APITagExtractor(FileWriter fileWriter) : base (fileWriter)
         {
             this.fileWriter = fileWriter;
         }
-
-        private async Task<string[]> GetAllOperationNames(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            JObject oOperations = new JObject();
-            int numOfOps = 0;
-            List<string> operationNames = new List<string>();
-            do
-            {
-                (string azToken, string azSubId) = await auth.GetAccessToken();
-
-                string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations?$skip={5}&api-version={6}",
-                   baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, numOfOps, GlobalConstants.APIVersion);
-                numOfOps += GlobalConstants.NumOfRecords;
-
-                string operations = await CallApiManagementAsync(azToken, requestUrl);
-
-                oOperations = JObject.Parse(operations);
-
-                foreach (var item in oOperations["value"])
-                {
-                    operationNames.Add(((JValue)item["name"]).Value.ToString());
-                }
-            }
-            while (oOperations["nextLink"] != null);
-            return operationNames.ToArray();
-        }
-
-        public async Task<string> GetAPIOperationDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}?api-version={6}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetOperationTagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}/tags?api-version={6}&format=rawxml",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPIDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<JToken[]> GetAllAPIObjsAsync(string ApiManagementName, string ResourceGroupName)
-        {
-            JObject oApi = new JObject();
-            int numOfApis = 0;
-            List<JToken> apiObjs = new List<JToken>();
-            do
-            {
-                (string azToken, string azSubId) = await auth.GetAccessToken();
-
-                string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?$skip={4}&api-version={5}",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, numOfApis, GlobalConstants.APIVersion);
-                numOfApis += GlobalConstants.NumOfRecords;
-
-                string apis = await CallApiManagementAsync(azToken, requestUrl);
-
-                oApi = JObject.Parse(apis);
-
-                foreach (var item in oApi["value"])
-                {
-                    apiObjs.Add(item);
-                }
-            }
-            while (oApi["nextLink"] != null);
-            return apiObjs.ToArray();
-        }
-
-        public async Task<string> GetAPITagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/tags?api-version={5}",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
+        
         public async Task<List<TemplateResource>> GenerateSingleAPITagResourceAsync(string apiName, Extractor exc, string[] dependsOn)
         {
             List<TemplateResource> templateResources = new List<TemplateResource>();

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
@@ -54,16 +54,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<string> GetOperationPolicyAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/operations/{5}/policies/policy?api-version={6}&format=rawxml",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
         public async Task<string> GetOperationTagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string OperationId)
         {
             (string azToken, string azSubId) = await auth.GetAccessToken();
@@ -72,19 +62,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, OperationId, GlobalConstants.APIVersion);
 
             return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPIServiceUrl(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            string apiDetails = await CallApiManagementAsync(azToken, requestUrl);
-            JObject oApiDetails = JObject.Parse(apiDetails);
-            APITemplateResource apiResource = JsonConvert.DeserializeObject<APITemplateResource>(apiDetails);
-            return apiResource.properties.serviceUrl;
         }
 
         public async Task<string> GetAPIDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
@@ -123,93 +100,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return apiObjs.ToArray();
         }
 
-        public async Task<List<string>> GetAllAPINamesAsync(string ApiManagementName, string ResourceGroupName)
-        {
-            JToken[] oApis = await GetAllAPIObjsAsync(ApiManagementName, ResourceGroupName);
-            List<string> apiNames = new List<string>();
-
-            foreach (JToken curApi in oApis)
-            {
-                string apiName = ((JValue)curApi["name"]).Value.ToString();
-                apiNames.Add(apiName);
-            }
-            return apiNames;
-        }
-
-        public async Task<string> GetAPIChangeLogAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/releases?api-version={5}",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPIRevisionsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/revisions?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPIPolicyAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/policies/policy?api-version={5}&format=rawxml",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
         public async Task<string> GetAPITagsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
         {
             (string azToken, string azSubId) = await auth.GetAccessToken();
 
             string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/tags?api-version={5}",
                 baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-        public async Task<string> GetAPIDiagnosticsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/diagnostics?api-version={5}",
-                baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPIProductsAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/products?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPISchemasAsync(string ApiManagementName, string ResourceGroupName, string ApiName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/schemas?api-version={5}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, GlobalConstants.APIVersion);
-
-            return await CallApiManagementAsync(azToken, requestUrl);
-        }
-
-        public async Task<string> GetAPISchemaDetailsAsync(string ApiManagementName, string ResourceGroupName, string ApiName, string schemaName)
-        {
-            (string azToken, string azSubId) = await auth.GetAccessToken();
-
-            string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}/schemas/{5}?api-version={6}",
-               baseUrl, azSubId, ResourceGroupName, ApiManagementName, ApiName, schemaName, GlobalConstants.APIVersion);
 
             return await CallApiManagementAsync(azToken, requestUrl);
         }
@@ -294,43 +190,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return templateResources;
         }
 
-        // this function generate apiTemplate for single api with all its revisions
-        public async Task<Template> GenerateAPITagRevisionTemplateAsync(string currentRevision, List<string> revList, string apiName, Extractor exc, string[] dependsOn)
-        {
-            // generate apiTemplate
-            Template armTemplate = GenerateEmptyTemplateWithParameters(exc.policyXMLBaseUrl, exc.policyXMLSasToken);
-            List<TemplateResource> templateResources = new List<TemplateResource>();
-            Console.WriteLine("{0} APIs found ...", revList.Count().ToString());
-
-            List<TemplateResource> apiResources = await GenerateSingleAPITagResourceAsync(apiName, exc, dependsOn);
-            templateResources.AddRange(apiResources);
-
-            string lastAPITagName = null;
-
-            foreach (string curApi in revList)
-            {
-                // add current API revision resource to template
-                apiResources = await GenerateSingleAPITagResourceAsync(curApi, exc, (lastAPITagName != null ? new string[] { lastAPITagName } : dependsOn));
-                templateResources.AddRange(apiResources);
-
-                // Extract the tag name from the last resource
-                string[] lastTagName = apiResources.Last().name.Replace("')]", "").Split('/');
-                if (lastTagName.Length > 3)
-                {
-                    // Operations tag
-                    lastAPITagName = $"[resourceId('Microsoft.ApiManagement/service/apis/operations/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{lastTagName[2]}', '{lastTagName[3]}')]";
-                }
-                else
-                {
-                    // API tag
-                    lastAPITagName = $"[resourceId('Microsoft.ApiManagement/service/apis/tags', parameters('{ParameterNames.ApimServiceName}'), '{apiName}', '{lastTagName[2]}')]";
-                }
-            }
-
-            armTemplate.resources = templateResources.ToArray();
-            return armTemplate;
-        }
-
         public async Task<Template> GenerateAPITagsARMTemplateAsync(string singleApiName, List<string> multipleApiNames, Extractor exc)
         {
             // initialize arm template
@@ -403,103 +262,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             }
             armTemplate.resources = templateResources.ToArray();
             return armTemplate;
-        }
-
-        private static void ArmEscapeSampleValueIfNecessary(OperationTemplateRepresentation operationTemplateRepresentation)
-        {
-            if (!string.IsNullOrWhiteSpace(operationTemplateRepresentation.sample) && operationTemplateRepresentation.contentType?.Contains("application/json", StringComparison.OrdinalIgnoreCase) == true && operationTemplateRepresentation.sample.TryParseJson(out JToken sampleAsJToken) && sampleAsJToken.Type == JTokenType.Array)
-            {
-                operationTemplateRepresentation.sample = "[" + operationTemplateRepresentation.sample;
-            }
-        }
-
-        private static void AddSchemaDependencyToOperationIfNecessary(string oApiName, List<string> operationDependsOn, OperationTemplateRepresentation operationTemplateRepresentation)
-        {
-            if (operationTemplateRepresentation.schemaId != null)
-            {
-                string dependsOn = $"[resourceId('Microsoft.ApiManagement/service/apis/schemas', parameters('{ParameterNames.ApimServiceName}'), '{oApiName}', '{operationTemplateRepresentation.schemaId}')]";
-                // add value to list if schema has not already been added
-                if (!operationDependsOn.Exists(o => o == dependsOn))
-                {
-                    operationDependsOn.Add(dependsOn);
-                }
-            }
-        }
-
-        private static bool CheckAPIExist(string singleApiName, JObject oApi)
-        {
-            for (int i = 0; i < ((JContainer)oApi["value"]).Count; i++)
-            {
-                if (((JValue)oApi["value"][i]["name"]).Value.ToString().Equals(singleApiName))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private async Task<List<TemplateResource>> GenerateSchemasARMTemplate(string apimServiceName, string apiName, string resourceGroup, string fileFolder)
-        {
-            List<TemplateResource> templateResources = new List<TemplateResource>();
-
-            // pull all schemas from service
-            string schemas = await GetAPISchemasAsync(apimServiceName, resourceGroup, apiName);
-            JObject oSchemas = JObject.Parse(schemas);
-
-            foreach (var item in oSchemas["value"])
-            {
-                string schemaName = ((JValue)item["name"]).Value.ToString();
-                Console.WriteLine("'{0}' Operation schema found", schemaName);
-
-                string schemaDetails = await GetAPISchemaDetailsAsync(apimServiceName, resourceGroup, apiName, schemaName);
-
-                // pull returned schema and convert to template resource
-                RESTReturnedSchemaTemplate restReturnedSchemaTemplate = JsonConvert.DeserializeObject<RESTReturnedSchemaTemplate>(schemaDetails);
-                SchemaTemplateResource schemaDetailsResource = JsonConvert.DeserializeObject<SchemaTemplateResource>(schemaDetails);
-                schemaDetailsResource.properties.document.value = GetSchemaValueBasedOnContentType(restReturnedSchemaTemplate.properties);
-                schemaDetailsResource.name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{schemaName}')]";
-                schemaDetailsResource.apiVersion = GlobalConstants.APIVersion;
-                schemaDetailsResource.dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
-
-                templateResources.Add(schemaDetailsResource);
-
-            }
-            return templateResources;
-        }
-
-        private string GetSchemaValueBasedOnContentType(RESTReturnedSchemaTemplateProperties schemaTemplateProperties)
-        {
-            var contentType = schemaTemplateProperties.contentType.ToLowerInvariant();
-            if (contentType.Equals("application/vnd.oai.openapi.components+json"))
-            {
-                // for OpenAPI "value" is not used, but "components" which is resolved during json deserialization
-                return null;
-            }
-
-            if (!(schemaTemplateProperties.document is JToken))
-            {
-                return JsonConvert.SerializeObject(schemaTemplateProperties.document);
-            }
-
-            var schemaJson = schemaTemplateProperties.document as JToken;
-
-            switch (contentType)
-            {
-                case "application/vnd.ms-azure-apim.swagger.definitions+json":
-                    if (schemaJson["definitions"] != null && schemaJson.Count() == 1)
-                    {
-                        schemaJson = schemaJson["definitions"];
-                    }
-                    break;
-                case "application/vnd.ms-azure-apim.xsd+xml":
-                    if (schemaJson["value"] != null && schemaJson.Count() == 1)
-                    {
-                        return schemaJson["value"].ToString();
-                    }
-                    break;
-            }
-
-            return JsonConvert.SerializeObject(schemaJson);
         }
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/ExtractorUtils.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/ExtractorUtils.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             PolicyExtractor policyExtractor = new PolicyExtractor(fileWriter);
             PropertyExtractor propertyExtractor = new PropertyExtractor();
             TagExtractor tagExtractor = new TagExtractor();
+            ProductAPIExtractor productAPIExtractor = new ProductAPIExtractor(fileWriter);
             ProductExtractor productExtractor = new ProductExtractor(fileWriter);
             MasterTemplateExtractor masterTemplateExtractor = new MasterTemplateExtractor();
 
@@ -97,6 +98,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             Template authorizationServerTemplate = await authorizationServerExtractor.GenerateAuthorizationServersARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, policyXMLSasToken);
             Template loggerTemplate = await loggerExtractor.GenerateLoggerTemplateAsync(exc, singleApiName, apiTemplateResources, apiLoggerId);
             Template productTemplate = await productExtractor.GenerateProductsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, policyXMLSasToken, dirName);
+            Template productAPITemplate = await productAPIExtractor.GenerateAPIProductsARMTemplateAsync(singleApiName, multipleApiNames, exc);
             List<TemplateResource> productTemplateResources = productTemplate.resources.ToList();
             Template namedValueTemplate = await propertyExtractor.GenerateNamedValuesTemplateAsync(singleApiName, apiTemplateResources, exc);
             Template tagTemplate = await tagExtractor.GenerateTagsTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, productTemplateResources, policyXMLBaseUrl, policyXMLSasToken);
@@ -139,6 +141,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             {
                 fileWriter.WriteJSONToFile(productTemplate, String.Concat(@dirName, fileNames.products));
             }
+            if (productAPITemplate.resources.Count() != 0)
+            {
+                fileWriter.WriteJSONToFile(productAPITemplate, String.Concat(@dirName, fileNames.productAPIs));
+            }
             if (tagTemplate.resources.Count() != 0)
             {
                 fileWriter.WriteJSONToFile(tagTemplate, String.Concat(@dirName, fileNames.tags));
@@ -155,7 +161,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             {
                 // create a master template that links to all other templates
                 Template masterTemplate = masterTemplateExtractor.GenerateLinkedMasterTemplate(
-                    apiTemplate, globalServicePolicyTemplate, apiVersionSetTemplate, productTemplate,
+                    apiTemplate, globalServicePolicyTemplate, apiVersionSetTemplate, productTemplate, productAPITemplate,
                     loggerTemplate, backendTemplate, authorizationServerTemplate, namedValueTemplate,
                     tagTemplate, fileNames, apiFileName, exc);
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/ExtractorUtils.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/ExtractorUtils.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             PropertyExtractor propertyExtractor = new PropertyExtractor();
             TagExtractor tagExtractor = new TagExtractor();
             ProductAPIExtractor productAPIExtractor = new ProductAPIExtractor(fileWriter);
+            APITagExtractor apiTagExtractor = new APITagExtractor(fileWriter);
             ProductExtractor productExtractor = new ProductExtractor(fileWriter);
             MasterTemplateExtractor masterTemplateExtractor = new MasterTemplateExtractor();
 
@@ -99,6 +100,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             Template loggerTemplate = await loggerExtractor.GenerateLoggerTemplateAsync(exc, singleApiName, apiTemplateResources, apiLoggerId);
             Template productTemplate = await productExtractor.GenerateProductsARMTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, policyXMLBaseUrl, policyXMLSasToken, dirName);
             Template productAPITemplate = await productAPIExtractor.GenerateAPIProductsARMTemplateAsync(singleApiName, multipleApiNames, exc);
+            Template apiTagTemplate = await apiTagExtractor.GenerateAPITagsARMTemplateAsync(singleApiName, multipleApiNames, exc);
             List<TemplateResource> productTemplateResources = productTemplate.resources.ToList();
             Template namedValueTemplate = await propertyExtractor.GenerateNamedValuesTemplateAsync(singleApiName, apiTemplateResources, exc);
             Template tagTemplate = await tagExtractor.GenerateTagsTemplateAsync(sourceApim, resourceGroup, singleApiName, apiTemplateResources, productTemplateResources, policyXMLBaseUrl, policyXMLSasToken);
@@ -145,6 +147,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             {
                 fileWriter.WriteJSONToFile(productAPITemplate, String.Concat(@dirName, fileNames.productAPIs));
             }
+            if (apiTagTemplate.resources.Count() != 0)
+            {
+                fileWriter.WriteJSONToFile(apiTagTemplate, String.Concat(@dirName, fileNames.apiTags));
+            }
             if (tagTemplate.resources.Count() != 0)
             {
                 fileWriter.WriteJSONToFile(tagTemplate, String.Concat(@dirName, fileNames.tags));
@@ -162,7 +168,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 // create a master template that links to all other templates
                 Template masterTemplate = masterTemplateExtractor.GenerateLinkedMasterTemplate(
                     apiTemplate, globalServicePolicyTemplate, apiVersionSetTemplate, productTemplate, productAPITemplate,
-                    loggerTemplate, backendTemplate, authorizationServerTemplate, namedValueTemplate,
+                    apiTagTemplate, loggerTemplate, backendTemplate, authorizationServerTemplate, namedValueTemplate,
                     tagTemplate, fileNames, apiFileName, exc);
 
                 fileWriter.WriteJSONToFile(masterTemplate, String.Concat(@dirName, fileNames.linkedMaster));


### PR DESCRIPTION
I identified at least two points where the PessimisticConcurrencyConflict may arise - when several APIs share a product, or when they share tags. The resource that associates the API and the product, or the API and the tag, locks both resources; so if another API tries to create an association with the same product or tag simultaneously, there will be a conflict.

My solution:

**Products**
Separate the product/API association resources into their own template, which depends on the API and product templates. The product/API resources depend on each other in a chain, forcing them to be deployed serially rather than in parallel. Same solution for Creator and Extractor.

**Tags**
In Extractor, separate the tag/API association resources into their own template, which depends on the API and tag templates. The tag/API resources depend on each other in a chain, forcing them to be deployed serially rather than in parallel.

In Creator, tags may be in the OpenAPI spec as well as the ARM template. In this case, the only option to avoid the concurrency conflict is to deploy the APIs serially. If the API template depends on the tags template, APIs are deployed serially; otherwise, they are deployed in parallel as normal.