### PR TITLE
Allow to parametrize serviceUrl

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
 
             // assert
             Assert.Equal($"[concat(parameters('ApimServiceName'), '/{api.name}')]", apiTemplateResource.name);
-            Assert.Equal($"[parameters('{ParameterNames.ServiceUrl}')]", apiTemplateResource.properties.serviceUrl);
+            Assert.Equal($"[parameters('{ParameterNames.ServiceUrl}').{api.name}]", apiTemplateResource.properties.serviceUrl);
             Assert.Equal(api.name, apiTemplateResource.properties.displayName);
             Assert.Equal(api.apiVersion, apiTemplateResource.properties.apiVersion);
             Assert.Equal(api.apiVersionDescription, apiTemplateResource.properties.apiVersionDescription);

--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
 
             // assert
             Assert.Equal($"[concat(parameters('ApimServiceName'), '/{api.name}')]", apiTemplateResource.name);
+            Assert.Equal($"[parameters('{ParameterNames.ServiceUrl}')]", apiTemplateResource.properties.serviceUrl);
             Assert.Equal(api.name, apiTemplateResource.properties.displayName);
             Assert.Equal(api.apiVersion, apiTemplateResource.properties.apiVersion);
             Assert.Equal(api.apiVersionDescription, apiTemplateResource.properties.apiVersionDescription);
@@ -68,6 +69,29 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             Assert.Equal(api.authenticationSettings.openid.openidProviderId, apiTemplateResource.properties.authenticationSettings.openid.openidProviderId);
             Assert.Equal(api.authenticationSettings.openid.bearerTokenSendingMethods, apiTemplateResource.properties.authenticationSettings.openid.bearerTokenSendingMethods);
             Assert.Equal(api.authenticationSettings.subscriptionKeyRequired, apiTemplateResource.properties.authenticationSettings.subscriptionKeyRequired);
+        }
+
+        [Fact]
+        public async void ShouldCreateAPITemplateResourceFromCreatorConfigWithServiceUrl()
+        {
+            // arrange
+            APITemplateCreator apiTemplateCreator = APITemplateCreatorFactory.GenerateAPITemplateCreator();
+            CreatorConfig creatorConfig = new CreatorConfig() { apis = new List<APIConfig>() };
+            APIConfig api = new APIConfig()
+            {
+                name = "name",
+                openApiSpec = "https://petstore.swagger.io/v2/swagger.json",
+                serviceUrl = "https://petstore.swagger.io"
+            };
+            creatorConfig.apis.Add(api);
+
+            // act
+            // the above api config will create a unified api template with a single resource
+            List<Template> apiTemplates = await apiTemplateCreator.CreateAPITemplatesAsync(api);
+            APITemplateResource apiTemplateResource = apiTemplates.FirstOrDefault().resources[0] as APITemplateResource;
+
+            // assert
+            Assert.Equal("https://petstore.swagger.io", apiTemplateResource.properties.serviceUrl);
         }
 
         [Fact]

--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
         }
 
         [Fact]
-        public async void ShouldCreateAPITemplateResourceFromCreatorConfigWithServiceUrl()
+        public async void ShouldCreateAPITemplateResourceFromCreatorConfigWithoutServiceUrlParameter()
         {
             // arrange
             APITemplateCreator apiTemplateCreator = APITemplateCreatorFactory.GenerateAPITemplateCreator();
@@ -91,6 +91,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
             APITemplateResource apiTemplateResource = apiTemplates.FirstOrDefault().resources[0] as APITemplateResource;
 
             // assert
+            Assert.Single(apiTemplates.First().parameters);
+            Assert.False(apiTemplates.First().parameters.ContainsKey(ParameterNames.ServiceUrl));
             Assert.Equal("https://petstore.swagger.io", apiTemplateResource.properties.serviceUrl);
         }
 

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -4,6 +4,7 @@ using System;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
 using apimtemplate.Creator.Utilities;
 using System.Net;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 {
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 
             if (String.IsNullOrEmpty(api.serviceUrl))
             {
-                apiTemplate.parameters.Add(ParameterNames.ServiceUrl, new TemplateParameterProperties() { type = "string" });
+                apiTemplate.parameters.Add(ParameterNames.ServiceUrl, new TemplateParameterProperties() { type = "object" });
             }
 
             List<TemplateResource> resources = new List<TemplateResource>();
@@ -129,7 +130,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             {
                 // add metadata properties for initial and unified templates
                 apiTemplateResource.properties.apiVersion = api.apiVersion;
-                apiTemplateResource.properties.serviceUrl = api.serviceUrl ?? $"[parameters('{ParameterNames.ServiceUrl}')]";
+                apiTemplateResource.properties.serviceUrl = MakeServiceUrl(api);
                 apiTemplateResource.properties.type = api.type;
                 apiTemplateResource.properties.apiType = api.type;
                 apiTemplateResource.properties.description = api.description;
@@ -229,7 +230,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 apiTemplateResource.properties.format = format;
                 apiTemplateResource.properties.value = value;
                 apiTemplateResource.properties.path = api.suffix;
-                apiTemplateResource.properties.serviceUrl = api.serviceUrl ?? $"[parameters('{ParameterNames.ServiceUrl}')]";
+                apiTemplateResource.properties.serviceUrl = MakeServiceUrl(api);
 
             }
             return apiTemplateResource;
@@ -258,6 +259,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
         {
             // the api needs to be split into multiple templates if the user has supplied a version or version set - deploying swagger related properties at the same time as api version related properties fails, so they must be written and deployed separately
             return apiConfig.apiVersion != null || apiConfig.apiVersionSetId != null || (apiConfig.authenticationSettings != null && apiConfig.authenticationSettings.oAuth2 != null && apiConfig.authenticationSettings.oAuth2.authorizationServerId != null);
+        }
+
+        private string MakeServiceUrl(APIConfig api)
+        {
+            return api.serviceUrl ?? $"[parameters('{ParameterNames.ServiceUrl}').{ExtractorUtils.GenValidParamName(api.name, ParameterPrefix.Api)}]";
         }
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -65,7 +65,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             // add parameters
             apiTemplate.parameters = new Dictionary<string, TemplateParameterProperties>
             {
-                { ParameterNames.ApimServiceName, new TemplateParameterProperties(){ type = "string" } }
+                { ParameterNames.ApimServiceName, new TemplateParameterProperties(){ type = "string" } },
+                { ParameterNames.ServiceUrl, new TemplateParameterProperties(){ type = "string" } }
             };
 
             List<TemplateResource> resources = new List<TemplateResource>();
@@ -124,7 +125,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             {
                 // add metadata properties for initial and unified templates
                 apiTemplateResource.properties.apiVersion = api.apiVersion;
-                apiTemplateResource.properties.serviceUrl = api.serviceUrl;
+                apiTemplateResource.properties.serviceUrl = api.serviceUrl ?? $"[parameters('{ParameterNames.ServiceUrl}')]";
                 apiTemplateResource.properties.type = api.type;
                 apiTemplateResource.properties.apiType = api.type;
                 apiTemplateResource.properties.description = api.description;
@@ -224,8 +225,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 apiTemplateResource.properties.format = format;
                 apiTemplateResource.properties.value = value;
                 apiTemplateResource.properties.path = api.suffix;
-                apiTemplateResource.properties.serviceUrl = api.serviceUrl;
-               
+                apiTemplateResource.properties.serviceUrl = api.serviceUrl ?? $"[parameters('{ParameterNames.ServiceUrl}')]";
+
             }
             return apiTemplateResource;
         }

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -65,9 +65,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
             // add parameters
             apiTemplate.parameters = new Dictionary<string, TemplateParameterProperties>
             {
-                { ParameterNames.ApimServiceName, new TemplateParameterProperties(){ type = "string" } },
-                { ParameterNames.ServiceUrl, new TemplateParameterProperties(){ type = "string" } }
+                { ParameterNames.ApimServiceName, new TemplateParameterProperties(){ type = "string" } }
             };
+
+            if (String.IsNullOrEmpty(api.serviceUrl))
+            {
+                apiTemplate.parameters.Add(ParameterNames.ServiceUrl, new TemplateParameterProperties() { type = "string" });
+            }
 
             List<TemplateResource> resources = new List<TemplateResource>();
             // create api resource 


### PR DESCRIPTION
### What this PR does / why we need it:

This PR add support to parametrize serviceUrl in ARM templates in order to be able to set by environemt from a CI/CD pipeline.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

 - [X] Code compiles correctly
 - [X] Created/updated tests
 - [X] Unit tests passing
 - [X] End-to-end tests passing
 - [ ] Add documentation
 - [ ] Provided sample for the feature

If you don't set serviceUrl property in yml file or you don't pass --backendurlconfigFile in create commandline arguments:

```powershell
apim-templates create --configFile apim.yml
```

![image](https://user-images.githubusercontent.com/1729519/103227943-ed645c00-492f-11eb-9d48-2cef1668f352.png)

When you set serviceUrl property in yml file or you pass --backendurlconfigFile in create commandline arguments:

```powershell
apim-templates create --configFile apim.yml --backendurlconfigFile ..\serviceUrl.json
```

![image](https://user-images.githubusercontent.com/1729519/103268133-45907200-49b3-11eb-880c-33a5d872f8cc.png)

Regards!