### PR TITLE
Remove 'properties' property from ProductAPITemplateResource

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/ProductAPITemplateResource.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/ProductAPITemplateResource.cs
@@ -3,8 +3,5 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
 {
     public class ProductAPITemplateResource : TemplateResource
     {
-        public ProductAPITemplateProperties properties { get; set; }
     }
-
-    public class ProductAPITemplateProperties { }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductAPITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/ProductAPITemplateCreator.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{productID}/{apiName}')]",
                 type = ResourceTypeConstants.ProductAPI,
                 apiVersion = GlobalConstants.APIVersion,
-                properties = new ProductAPITemplateProperties(),
                 dependsOn = dependsOn
             };
             return productAPITemplateResource;


### PR DESCRIPTION
'properties' is not a valid property for the [Microsoft.ApiManagement/service/products/apis](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-12-01/service/products/apis?tabs=json) resource.

Having this property on the resource in the ARM template causes validation tooling to flag it as an error.