### PR TITLE
Added support for KeyVault Named Values (new parameter)

### DIFF
--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -381,10 +381,11 @@ You have two choices when specifying your settings:
 | serviceUrlParameters  | No                    | Parameterize service url in advance (you can replace serviceUrl afterwards as well, you can refer example for more information).  |
 |  paramServiceUrl | No                    |  Set to "true" will parameterize all serviceUrl for each api and generate serviceUrl parameter to api template/parameter template/master template files |
 |  paramNamedValue | No                    |  Set to "true" will parameterize all named values and add named values parameter to property template/parameter template/mastert emplate files |
-|  paramApiLoggerId | No                    |  Set to "true" will parameterize all logger ids in all apis (within api templates) |
+|  paramApiLoggerId | No                    |  Set to "true" will parameterize all logger ids in all apis (within api templates), Also includes the "All API" monitoring configuration |
 |  paramLogResourceId | No                    |  Set to "true" will parameterize all loggers' resource ids (within logger template)|
 | serviceBaseUrl | No                    | Specify the base url where you want to run your extractor |
 | notIncludeNamedValue | No                    | Set to "true" will not generate Named Value Templates|
+| paramNamedValuesKeyVaultSecrets | No | Set to true will parameterize all named values where the value is from a key vault secret |
 
 #### Note
 * Can not use "splitAPIs" and "apiName" at the same time, since using "apiName" only extract one API

--- a/src/APIM_ARMTemplate/apimtemplate/Common/Constants/GlobalConstants.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/Constants/GlobalConstants.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public const string LinkedTemplatesSasToken = "LinkedTemplatesSasToken";
         public const string ApimServiceName = "ApimServiceName";
         public const string LinkedTemplatesBaseUrl = "LinkedTemplatesBaseUrl";
+        public const string NamedValueKeyVaultSecrets = "NamedValueKeyVaultSecrets";
     }
 
     public static class ParameterPrefix

--- a/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/PropertyTemplateResource.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/PropertyTemplateResource.cs
@@ -13,5 +13,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public bool secret { get; set; }
         public string displayName { get; set; }
         public string value { get; set; }
+        public PropertyResourceKeyVaultProperties keyVault { get; set; }
+    }
+
+    public class PropertyResourceKeyVaultProperties
+    {
+        public string secretIdentifier { get; set; }
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/EntityExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/EntityExtractor.cs
@@ -74,6 +74,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 };
                 armTemplate.parameters.Add(ParameterNames.NamedValues, namedValueParameterProperties);
             }
+            if (exc.paramNamedValuesKeyVaultSecrets)
+            {
+                TemplateParameterProperties keyVaultNamedValueParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "object"
+                };
+                armTemplate.parameters.Add(ParameterNames.NamedValueKeyVaultSecrets, keyVaultNamedValueParameterProperties);
+            }
             return armTemplate;
         }
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PropertyExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PropertyExtractor.cs
@@ -83,6 +83,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     propertyTemplateResource.properties.value = $"[parameters('{ParameterNames.NamedValues}').{ExtractorUtils.GenValidParamName(propertyName, ParameterPrefix.Property)}]";
                 }
 
+                if (propertyTemplateResource.properties.keyVault != null && exc.paramNamedValuesKeyVaultSecrets )
+                {
+                    propertyTemplateResource.properties.value = null;
+                    propertyTemplateResource.properties.keyVault.secretIdentifier = $"[parameters('{ParameterNames.NamedValueKeyVaultSecrets}').{ExtractorUtils.GenValidParamName(propertyName, ParameterPrefix.Property)}]";
+                }
+
                 if (singleApiName == null)
                 {
                     // if the user is executing a full extraction, extract all the loggers

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PropertyExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PropertyExtractor.cs
@@ -83,9 +83,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     propertyTemplateResource.properties.value = $"[parameters('{ParameterNames.NamedValues}').{ExtractorUtils.GenValidParamName(propertyName, ParameterPrefix.Property)}]";
                 }
 
-                if (propertyTemplateResource.properties.keyVault != null && exc.paramNamedValuesKeyVaultSecrets )
+                //Hide the value field if it is a keyvault named value
+                if (propertyTemplateResource.properties.keyVault != null)
                 {
                     propertyTemplateResource.properties.value = null;
+                }
+
+                if (propertyTemplateResource.properties.keyVault != null && exc.paramNamedValuesKeyVaultSecrets )
+                {
                     propertyTemplateResource.properties.keyVault.secretIdentifier = $"[parameters('{ParameterNames.NamedValueKeyVaultSecrets}').{ExtractorUtils.GenValidParamName(propertyName, ParameterPrefix.Property)}]";
                 }
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/Models/ExtractorConfiguration.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/Models/ExtractorConfiguration.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         [Description("Should not include named values template")]
         public string notIncludeNamedValue { get; set; }
 
+        [Description("Parameterize named values where value is retrieved from a Key Vault secret")]
+        public bool paramNamedValuesKeyVaultSecrets { get; set; }
+
         [Description("Group the operations into batches of x?")]
         public int operationBatchSize {get;set;}
         public void Validate()
@@ -110,6 +113,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         public bool paramApiLoggerId { get; private set; }
         public bool paramLogResourceId { get; private set; }
         public bool notIncludeNamedValue { get; private set; }
+        public bool paramNamedValuesKeyVaultSecrets { get; private set; }
 
         public int operationBatchSize { get; private set;} 
 
@@ -133,6 +137,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             this.paramLogResourceId = exc.paramLogResourceId != null && exc.paramLogResourceId.Equals("true");
             this.notIncludeNamedValue = exc.notIncludeNamedValue != null && exc.notIncludeNamedValue.Equals("true");
             this.operationBatchSize  = exc.operationBatchSize;
+            this.paramNamedValuesKeyVaultSecrets = exc.paramNamedValuesKeyVaultSecrets;
         }
 
         public Extractor(ExtractorConfig exc) : this(exc, exc.fileFolder)


### PR DESCRIPTION
This change adds a new parameter to control the extraction of NamedValues where the secret is loaded from KeyVault.  
paramNamedValuesKeyVaultSecrets
This uses a similar pattern to the paramNamedValues property and generates an object parameter containing the keyvault references.

Addresses #511