### PR TITLE
serviceUrl param is missing from apiTag template link

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             if (apiTagsTemplate != null && apiTagsTemplate.resources.Count() != 0)
             {
                 string apiTagsUri = GenerateLinkedTemplateUri(exc.linkedTemplatesUrlQueryString, exc.linkedTemplatesSasToken, fileNames.apiTags);
-                resources.Add(this.CreateLinkedMasterTemplateResourceWithPolicyToken("apiTagsTemplate", apiTagsUri, apiTagDependsOn.ToArray(), exc));
+                resources.Add(this.CreateLinkedMasterTemplateResourceForApiTemplate("apiTagsTemplate", apiTagsUri, apiTagDependsOn.ToArray(), exc));
             }
             Console.WriteLine("Master template generated");
             masterTemplate.resources = resources.ToArray();


### PR DESCRIPTION
`APITagExtractor.GenerateAPITagsARMTemplateAsync` calls `GenerateEmptyApiTemplateWithParameters(exc)` which add parameter serviceUrl.

Adding the apiTagsTemplate to the master template is done via `CreateLinkedMasterTemplateResourceWithPolicyToken` which does not add serviceUrl to the parameters.

This causes a broken deployment, template is expecting serviceUrl which master template is not providing