### PR TITLE
For #531. Escape HTML when serializing swagger to string

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Creator/Utilities/OpenApi.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/Utilities/OpenApi.cs
@@ -52,7 +52,8 @@ namespace apimtemplate.Creator.Utilities
             }
             else
             {
-                return JsonConvert.SerializeObject(definition_);
+                // include StringEscaping to ensure single quotes are escaped
+                return JsonConvert.SerializeObject(definition_, settings: new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml});
             }
         }
 


### PR DESCRIPTION
Ensures single quotes are escaped, otherwise the template becomes invalid.