### PR TITLE
Added support for parameterising backend properties 

### DIFF
--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -386,6 +386,7 @@ You have two choices when specifying your settings:
 | serviceBaseUrl | No                    | Specify the base url where you want to run your extractor |
 | notIncludeNamedValue | No                    | Set to "true" will not generate Named Value Templates|
 | paramNamedValuesKeyVaultSecrets | No | Set to true will parameterize all named values where the value is from a key vault secret |
+| paramBackend | No | Set to true will parameterize sepcific backend values (limited to resourceId, url and protocol) |
 
 #### Note
 * Can not use "splitAPIs" and "apiName" at the same time, since using "apiName" only extract one API

--- a/src/APIM_ARMTemplate/apimtemplate/Common/Constants/GlobalConstants.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/Constants/GlobalConstants.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public const string ApimServiceName = "ApimServiceName";
         public const string LinkedTemplatesBaseUrl = "LinkedTemplatesBaseUrl";
         public const string NamedValueKeyVaultSecrets = "NamedValueKeyVaultSecrets";
+        public const string BackendSettings = "BackendSettings";
     }
 
     public static class ParameterPrefix
@@ -43,5 +44,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common
         public const string Diagnostic = "Diagnostic";
         public const string Property = "Property";
         public const string LogResourceId = "LogResourceId";
+        public const string Backend = "Backend";
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/BackendParameters.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Common/TemplateModels/BackendParameters.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace apimtemplate.Common.TemplateModels
+{
+    /// <summary>
+    /// Backend Parameters for a single API
+    /// </summary>
+    public class BackendApiParameters
+    {
+        public string resourceId { get; set; }
+        public string url { get; set; }
+        public string protocol { get; set; }
+    }
+
+}

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -827,5 +827,44 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
             return templateResources.ToArray();
         }
+
+        public Template GenerateEmptyApiTemplateWithParameters(Extractor exc)
+        {
+            Template armTemplate = GenerateEmptyTemplate();
+            armTemplate.parameters = new Dictionary<string, TemplateParameterProperties> { { ParameterNames.ApimServiceName, new TemplateParameterProperties() { type = "string" } } };
+            if (exc.policyXMLBaseUrl != null && exc.policyXMLSasToken != null)
+            {
+                TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "string"
+                };
+                armTemplate.parameters.Add(ParameterNames.PolicyXMLSasToken, policyTemplateSasTokenParameterProperties);
+            }
+            if (exc.policyXMLBaseUrl != null)
+            {
+                TemplateParameterProperties policyTemplateBaseUrlParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "string"
+                };
+                armTemplate.parameters.Add(ParameterNames.PolicyXMLBaseUrl, policyTemplateBaseUrlParameterProperties);
+            }
+            if (exc.paramServiceUrl || (exc.serviceUrlParameters != null && exc.serviceUrlParameters.Length > 0))
+            {
+                TemplateParameterProperties serviceUrlParamProperty = new TemplateParameterProperties()
+                {
+                    type = "object"
+                };
+                armTemplate.parameters.Add(ParameterNames.ServiceUrl, serviceUrlParamProperty);
+            }
+            if (exc.paramApiLoggerId)
+            {
+                TemplateParameterProperties apiLoggerProperty = new TemplateParameterProperties()
+                {
+                    type = "object"
+                };
+                armTemplate.parameters.Add(ParameterNames.ApiLoggerId, apiLoggerProperty);
+            }
+            return armTemplate;
+        }
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIVersionSetExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIVersionSetExtractor.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateAPIVersionSetsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl, string policyXMLSasToken)
+        public async Task<Template> GenerateAPIVersionSetsARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting API version sets from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
+            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters();
 
             // isolate apis in the case of a single api extraction
             var apiResources = apiTemplateResources.Where(resource => resource.type == ResourceTypeConstants.API);

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/AuthorizationServerExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/AuthorizationServerExtractor.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return await CallApiManagementAsync(azToken, requestUrl);
         }
 
-        public async Task<Template> GenerateAuthorizationServersARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources, string policyXMLBaseUrl, string policyXMLSasToken)
+        public async Task<Template> GenerateAuthorizationServersARMTemplateAsync(string apimname, string resourceGroup, string singleApiName, List<TemplateResource> apiTemplateResources)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting authorization servers from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
+            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters();
 
             List<TemplateResource> templateResources = new List<TemplateResource>();
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/EntityExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/EntityExtractor.cs
@@ -46,143 +46,15 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return armTemplate;
         }
 
-        public Template GenerateEmptyPropertyTemplateWithParameters(Extractor exc)
+        public Template GenerateEmptyPropertyTemplateWithParameters()
         {
             Template armTemplate = GenerateEmptyTemplate();
             armTemplate.parameters = new Dictionary<string, TemplateParameterProperties> { { ParameterNames.ApimServiceName, new TemplateParameterProperties() { type = "string" } } };
-            if (exc.policyXMLBaseUrl != null && exc.policyXMLSasToken != null)
-            {
-                TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "string"
-                };
-                armTemplate.parameters.Add(ParameterNames.PolicyXMLSasToken, policyTemplateSasTokenParameterProperties);
-            }
-            if (exc.policyXMLBaseUrl != null)
-            {
-                TemplateParameterProperties policyTemplateBaseUrlParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "string"
-                };
-                armTemplate.parameters.Add(ParameterNames.PolicyXMLBaseUrl, policyTemplateBaseUrlParameterProperties);
-            }
-            if (exc.paramNamedValue)
-            {
-                TemplateParameterProperties namedValueParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "object"
-                };
-                armTemplate.parameters.Add(ParameterNames.NamedValues, namedValueParameterProperties);
-            }
-            if (exc.paramNamedValuesKeyVaultSecrets)
-            {
-                TemplateParameterProperties keyVaultNamedValueParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "object"
-                };
-                armTemplate.parameters.Add(ParameterNames.NamedValueKeyVaultSecrets, keyVaultNamedValueParameterProperties);
-            }
             return armTemplate;
         }
 
-        public Template GenerateEmptyTemplateWithParameters(string policyXMLBaseUrl, string policyXMLSasToken)
-        {
-            Template armTemplate = GenerateEmptyTemplate();
-            armTemplate.parameters = new Dictionary<string, TemplateParameterProperties> { { ParameterNames.ApimServiceName, new TemplateParameterProperties() { type = "string" } } };
-            if (policyXMLBaseUrl != null && policyXMLSasToken != null)
-            {
-                TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "string"
-                };
-                armTemplate.parameters.Add(ParameterNames.PolicyXMLSasToken, policyTemplateSasTokenParameterProperties);
-            }
-            if (policyXMLBaseUrl != null)
-            {
-                TemplateParameterProperties policyTemplateBaseUrlParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "string"
-                };
-                armTemplate.parameters.Add(ParameterNames.PolicyXMLBaseUrl, policyTemplateBaseUrlParameterProperties);
-            }
-            return armTemplate;
-        }
 
-        public Template GenerateEmptyLoggerTemplateWithParameters(Extractor exc)
-        {
-            Template armTemplate = GenerateEmptyTemplate();
-            armTemplate.parameters = new Dictionary<string, TemplateParameterProperties> { { ParameterNames.ApimServiceName, new TemplateParameterProperties() { type = "string" } } };
-            if (exc.policyXMLBaseUrl != null && exc.policyXMLSasToken != null)
-            {
-                TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "string"
-                };
-                armTemplate.parameters.Add(ParameterNames.PolicyXMLSasToken, policyTemplateSasTokenParameterProperties);
-            }
-            if (exc.policyXMLBaseUrl != null)
-            {
-                TemplateParameterProperties policyTemplateBaseUrlParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "string"
-                };
-                armTemplate.parameters.Add(ParameterNames.PolicyXMLBaseUrl, policyTemplateBaseUrlParameterProperties);
-            }
-            if (exc.paramLogResourceId)
-            {
-                TemplateParameterProperties loggerResourceIdParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "object"
-                };
-                armTemplate.parameters.Add(ParameterNames.LoggerResourceId, loggerResourceIdParameterProperties);
-            }
-            return armTemplate;
-        }
+        
 
-        public Template GenerateEmptyApiTemplateWithParameters(Extractor exc)
-        {
-            Template armTemplate = GenerateEmptyTemplate();
-            armTemplate.parameters = new Dictionary<string, TemplateParameterProperties> { { ParameterNames.ApimServiceName, new TemplateParameterProperties() { type = "string" } } };
-            if (exc.policyXMLBaseUrl != null && exc.policyXMLSasToken != null)
-            {
-                TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "string"
-                };
-                armTemplate.parameters.Add(ParameterNames.PolicyXMLSasToken, policyTemplateSasTokenParameterProperties);
-            }
-            if (exc.policyXMLBaseUrl != null)
-            {
-                TemplateParameterProperties policyTemplateBaseUrlParameterProperties = new TemplateParameterProperties()
-                {
-                    type = "string"
-                };
-                armTemplate.parameters.Add(ParameterNames.PolicyXMLBaseUrl, policyTemplateBaseUrlParameterProperties);
-            }
-            if (exc.paramServiceUrl || (exc.serviceUrlParameters != null && exc.serviceUrlParameters.Length > 0))
-            {
-                TemplateParameterProperties serviceUrlParamProperty = new TemplateParameterProperties()
-                {
-                    type = "object"
-                };
-                armTemplate.parameters.Add(ParameterNames.ServiceUrl, serviceUrlParamProperty);
-            }
-            if (exc.paramApiLoggerId)
-            {
-                TemplateParameterProperties apiLoggerProperty = new TemplateParameterProperties()
-                {
-                    type = "object"
-                };
-                armTemplate.parameters.Add(ParameterNames.ApiLoggerId, apiLoggerProperty);
-            }
-            return armTemplate;
-        }
-
-        public Template GenerateEmptyProductApiTemplateWithParameters(Extractor exc)
-        {
-            Template armTemplate = GenerateEmptyTemplate();
-            armTemplate.parameters = new Dictionary<string, TemplateParameterProperties> { { ParameterNames.ApimServiceName, new TemplateParameterProperties() { type = "string" } } };
-            return armTemplate;
-        }
     }
 }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             return loggerTemplate;
         }
 
-        public async Task<Template> GenerateLoggerTemplateAsync(Extractor exc, string singleApiName, List<TemplateResource> apiTemplateResources, Dictionary<string, Dictionary<string, string>> apiLoggerId)
+        public async Task<Template> GenerateLoggerTemplateAsync(Extractor exc, string singleApiName, List<TemplateResource> apiTemplateResources, Dictionary<string, object> apiLoggerId)
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting loggers from service");
@@ -119,11 +119,15 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                     string validApiName = ExtractorUtils.GenValidParamName(singleApiName, ParameterPrefix.Api);
                     if (exc.paramApiLoggerId && apiLoggerId.ContainsKey(validApiName))
                     {
-                        Dictionary<string, string> curDiagnostic = apiLoggerId[validApiName];
-                        string validDName = ExtractorUtils.GenValidParamName(loggerResource.properties.loggerType, ParameterPrefix.Diagnostic).ToLower();
-                        if (curDiagnostic.ContainsKey(validDName) && curDiagnostic[validDName].Contains(loggerName))
+                        object diagnosticObj = apiLoggerId[validApiName];
+                        if (diagnosticObj is Dictionary<string, string>)
                         {
-                            isReferencedInDiagnostic = true;
+                            Dictionary<string, string> curDiagnostic = (Dictionary<string, string>)diagnosticObj;
+                            string validDName = ExtractorUtils.GenValidParamName(loggerResource.properties.loggerType, ParameterPrefix.Diagnostic).ToLower();
+                            if (curDiagnostic.ContainsKey(validDName) && curDiagnostic[validDName].Contains(loggerName))
+                            {
+                                isReferencedInDiagnostic = true;
+                            }
                         }
                     }
                     if (isReferencedInPolicy == true || isReferencedInDiagnostic == true)

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -67,7 +67,16 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting loggers from service");
-            Template armTemplate = GenerateEmptyLoggerTemplateWithParameters(exc);
+            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters();
+
+            if (exc.paramLogResourceId)
+            {
+                TemplateParameterProperties loggerResourceIdParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "object"
+                };
+                armTemplate.parameters.Add(ParameterNames.LoggerResourceId, loggerResourceIdParameterProperties);
+            }
 
             // isolate product api associations in the case of a single api extraction
             var policyResources = apiTemplateResources.Where(resource => (resource.type == ResourceTypeConstants.APIPolicy || resource.type == ResourceTypeConstants.APIOperationPolicy || resource.type == ResourceTypeConstants.ProductPolicy));

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         }
 
         public async Task<Template> CreateMasterTemplateParameterValues(List<string> apisToExtract, Extractor exc, 
-            Dictionary<string, Dictionary<string, string>> apiLoggerId, 
+            Dictionary<string, object> apiLoggerId, 
             Dictionary<string, string> loggerResourceIds,
             Dictionary<string, BackendApiParameters> backendParams)
         {

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PolicyExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PolicyExtractor.cs
@@ -30,7 +30,23 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             // extract global service policy in both full and single api extraction cases
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting global service policy from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
+            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters();
+            if (policyXMLBaseUrl != null && policyXMLSasToken != null)
+            {
+                TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "string"
+                };
+                armTemplate.parameters.Add(ParameterNames.PolicyXMLSasToken, policyTemplateSasTokenParameterProperties);
+            }
+            if (policyXMLBaseUrl != null)
+            {
+                TemplateParameterProperties policyTemplateBaseUrlParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "string"
+                };
+                armTemplate.parameters.Add(ParameterNames.PolicyXMLBaseUrl, policyTemplateBaseUrlParameterProperties);
+            }
 
             List<TemplateResource> templateResources = new List<TemplateResource>();
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         public async Task<Template> GenerateAPIProductsARMTemplateAsync(string singleApiName, List<string> multipleApiNames, Extractor exc)
         {
             // initialize arm template
-            Template armTemplate = GenerateEmptyProductApiTemplateWithParameters(exc);
+            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters();
             List<TemplateResource> templateResources = new List<TemplateResource>();
             // when extract single API
             if (singleApiName != null)

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PropertyExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/PropertyExtractor.cs
@@ -49,16 +49,33 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
         public async Task<Template> GenerateNamedValuesTemplateAsync(string singleApiName, List<TemplateResource> apiTemplateResources, Extractor exc)
         {
+            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters();
+
+            if (exc.paramNamedValue)
+            {
+                TemplateParameterProperties namedValueParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "object"
+                };
+                armTemplate.parameters.Add(ParameterNames.NamedValues, namedValueParameterProperties);
+            }
+            if (exc.paramNamedValuesKeyVaultSecrets)
+            {
+                TemplateParameterProperties keyVaultNamedValueParameterProperties = new TemplateParameterProperties()
+                {
+                    type = "object"
+                };
+                armTemplate.parameters.Add(ParameterNames.NamedValueKeyVaultSecrets, keyVaultNamedValueParameterProperties);
+            }
             if (exc.notIncludeNamedValue == true)
             {
                 Console.WriteLine("------------------------------------------");
                 Console.WriteLine("Skipping extracting named values from service");
-                return GenerateEmptyPropertyTemplateWithParameters(exc);
+                return armTemplate;
             }
 
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting named values from service");
-            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters(exc);
 
             List<TemplateResource> templateResources = new List<TemplateResource>();
 

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         public async Task<Template> GenerateAPITagsARMTemplateAsync(string singleApiName, List<string> multipleApiNames, Extractor exc)
         {
             // initialize arm template
-            Template armTemplate = GenerateEmptyApiTemplateWithParameters(exc);
+            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters();
             List<TemplateResource> templateResources = new List<TemplateResource>();
             // when extract single API
             if (singleApiName != null)

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagExtractor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         {
             Console.WriteLine("------------------------------------------");
             Console.WriteLine("Extracting tags from service");
-            Template armTemplate = GenerateEmptyTemplateWithParameters(policyXMLBaseUrl, policyXMLSasToken);
+            Template armTemplate = GenerateEmptyPropertyTemplateWithParameters();
 
             // isolate tag and api operation associations in the case of a single api extraction
             var apiOperationTagResources = apiTemplateResources.Where(resource => resource.type == ResourceTypeConstants.APIOperationTag);

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/Models/ExtractorConfiguration.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/Models/ExtractorConfiguration.cs
@@ -54,6 +54,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
         [Description("Group the operations into batches of x?")]
         public int operationBatchSize {get;set;}
+
+        [Description("Parameterize environment specific values from backend")]
+        public string paramBackend { get; set; }
+
         public void Validate()
         {
             if (string.IsNullOrEmpty(sourceApimName)) throw new ArgumentException("Missing parameter <sourceApimName>.");
@@ -115,7 +119,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
         public bool notIncludeNamedValue { get; private set; }
         public bool paramNamedValuesKeyVaultSecrets { get; private set; }
 
-        public int operationBatchSize { get; private set;} 
+        public int operationBatchSize { get; private set;}
+
+        public bool paramBackend { get; set; }
 
         public Extractor(ExtractorConfig exc, string dirName)
         {
@@ -138,6 +144,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
             this.notIncludeNamedValue = exc.notIncludeNamedValue != null && exc.notIncludeNamedValue.Equals("true");
             this.operationBatchSize  = exc.operationBatchSize;
             this.paramNamedValuesKeyVaultSecrets = exc.paramNamedValuesKeyVaultSecrets != null && exc.paramNamedValuesKeyVaultSecrets.Equals("true");
+            this.paramBackend = exc.paramBackend != null && exc.paramBackend.Equals("true");
         }
 
         public Extractor(ExtractorConfig exc) : this(exc, exc.fileFolder)


### PR DESCRIPTION
(currently limited to resourceId, url and protocol, so no service fabric at the moment) - Fix for #533 

Reworked parameters passed to linked templates to remove unused fields (PolicyXml* fields were passed and then never used)