### PR TITLE
[Creator] Support for Named Values from KeyVault

### DIFF
--- a/src/APIM_ARMTemplate/README.md
+++ b/src/APIM_ARMTemplate/README.md
@@ -113,9 +113,16 @@ _Additional properties found in [ProductContractProperties](https://docs.microso
 | tags                | array                | No                    | Optional tags that when provided can be used to filter the property list. - string
 | secret                | boolean                | No                    | Determines whether the value is a secret and should be encrypted or not. Default value is false.
 | displayName                | string                | Yes                    | Unique name of Property. It may contain only letters, digits, period, dash, and underscore characters.                          |
-| value                | string                | Yes                    | Value of the property. Can contain policy expressions. It may not be empty or consist only of whitespace.                          |
+| value                | string                | No                    | Value of the property. Can contain policy expressions. It can be empty or consist only of whitespace only if the keyvault parameter is set.                          |
+| keyvault                | [PropertyKeyVaultConfiguration](#PropertyKeyVaultConfiguration)                 | No                    | The keyvault settings for the property.                          |
 
 _Additional properties found in [PropertyContractProperties](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service/properties#propertycontractproperties-object)_
+
+#### PropertyKeyVaultConfiguration
+
+| Property              | Type                  | Required              | Value                                            |
+|-----------------------|-----------------------|-----------------------|--------------------------------------------------|
+| secretIdentifier                | string                | Yes                    | KeyVault secret id which will map to the property.   
 
 #### LoggerConfiguration
 

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PropertyTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PropertyTemplateCreator.cs
@@ -30,7 +30,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                         displayName = namedValue.displayName,
                         value = namedValue.value,
                         secret = namedValue.secret,
-                        tags = namedValue.tags
+                        tags = namedValue.tags,
+                        keyVault = namedValue.keyVault
+
                     },
                     dependsOn = new string[] {}
                 };


### PR DESCRIPTION
Building on the work done for the extractor I have added the following to the config file to support setting keyvault named values.

```
namedValues:
- displayName: KVSecret
  secret: true
  keyvault:
    secretIdentifier: https://mykeyvault.vault.azure.net/secrets/KVSecret2
```

documentation also updated to reflect new properties and changes to the mandatory nature of the value property (it is only mandatory if the keyvault value is not set)