### PR TITLE
Fixed deploying multiple versions of the same API

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Commands/Create.cs
@@ -135,6 +135,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     List<Template> apiTemplates = new List<Template>();
                     Console.WriteLine("Creating API templates");
                     Console.WriteLine("------------------------------------------");
+
+                    IDictionary<string, string[]> apiVersions = APITemplateCreator.GetApiVersionSets(creatorConfig);
+
                     foreach (APIConfig api in creatorConfig.apis)
                     {
                         if (considerAllApiForDeployments || preferredApis.Contains(api.name))
@@ -155,7 +158,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                                 name = api.name,
                                 isSplit = apiTemplateCreator.isSplitAPI(api),
                                 dependsOnGlobalServicePolicies = creatorConfig.policy != null,
-                                dependsOnVersionSets = api.apiVersionSetId != null,
+                            	dependsOnVersionSets = api.apiVersionSetId != null,
+                            	dependsOnVersion = masterTemplateCreator.GetDependsOnPreviousApiVersion(api, apiVersions),
                                 dependsOnProducts = api.products != null,
                                 dependsOnTags = api.tags != null,
                                 dependsOnLoggers = await masterTemplateCreator.DetermineIfAPIDependsOnLoggerAsync(api, fileReader),

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -239,7 +239,20 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 }
                 apiTemplateResource.properties.format = format;
                 apiTemplateResource.properties.value = value;
-                apiTemplateResource.properties.path = api.suffix;
+
+                // #562: deploying multiple versions of an API may fail because while trying to deploy the initial template
+                // overwrite the initial template’s path property to a dummy value
+                // this value will be restored when the subsequent template is deployed
+
+                if (isSplit && isInitial)
+                {
+                    apiTemplateResource.properties.path = api.suffix + $"/{Guid.NewGuid():n}";
+                }
+                else
+                {
+                    apiTemplateResource.properties.path = api.suffix;
+                }
+                
                 if (!String.IsNullOrEmpty(api.serviceUrl))
                 {
                     apiTemplateResource.properties.serviceUrl = MakeServiceUrl(api);

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
 using apimtemplate.Creator.Utilities;
 using System.Net;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract;
+using System.Linq;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 {
@@ -245,6 +246,22 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 }
             }
             return apiTemplateResource;
+        }
+
+        internal static IDictionary<string, string[]> GetApiVersionSets(CreatorConfig creatorConfig)
+        {
+            var apiVersions = (creatorConfig.apiVersionSets ?? new List<APIVersionSetConfig>())
+                .ToDictionary(v => v.id, v => new List<string>())
+                ;
+
+            foreach (var api in creatorConfig.apis.Where(a => !string.IsNullOrEmpty(a.apiVersionSetId)))
+                apiVersions[api.apiVersionSetId].Add(api.name)
+                    ;
+
+            return apiVersions.ToDictionary(
+                kv => kv.Key,
+                kv => kv.Value.OrderBy(v => v).ToArray()
+                );
         }
 
         private static string GetOpenApiSpecFormat(bool isUrl, bool isJSON, bool isVersionThree)


### PR DESCRIPTION
Fixes #562.

Before generating templates, the list of all APIs and their different versions are retrieved from the configuration file.

For each individual API, if the configuration file contains multiple versions of the same API exist, an order is determined based upon the version set identifier. New `dependsOn` directives are added to make sure that each version is deployed sequentially, one after the other.

Because each version comes in two ARM templates, respectively named `initial` and `subsequent` I also fixed an odd issue that prevents the `initial` template from deploying successfully because ARM thinks an API with the same suffix already exists. Therefore, the `initial` template deploys an API with a dummy GUID-based suffix, which gets overwritten by the correct suffix when deploying the `subsequent` template.
