### PR TITLE
Fixed incorrect detection of OpenAPI v3.* service contract.

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
+++ b/src/APIM_ARMTemplate/apimtemplate.test/Creator/TemplateCreatorTests/APITemplateCreatorTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Test
 
             // assert
             Assert.Equal($"[concat(parameters('ApimServiceName'), '/{api.name}')]", apiTemplateResource.name);
-            Assert.Equal("swagger-json", apiTemplateResource.properties.format);
+            Assert.Equal("swagger-link-json", apiTemplateResource.properties.format);
 
             // check alternate title has been specified in the embedded YAML or JSON definition
 

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/APITemplateCreator.cs
@@ -177,7 +177,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 string value;
 
                 // determine if the open api spec is remote or local, yaml or json
-                bool isJSON = false;
                 bool isUrl = IsUri(api, out var _);
 
                 string fileContents = null;
@@ -192,7 +191,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 bool isVersionThree = false;
                 if (api.openApiSpecFormat == OpenApiSpecFormat.Unspecified)
                 {
-                    isJSON = this.fileReader.isJSON(fileContents);
+                    bool isJSON = this.fileReader.isJSON(fileContents);
 
                     if (isJSON == true)
                     {
@@ -204,7 +203,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 
                 else
                 {
-                    isJSON = IsOpenApiSpecJson(api.openApiSpecFormat);
                     format = GetOpenApiSpecFormat(isUrl, api.openApiSpecFormat);
                 }
 
@@ -213,8 +211,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 
                 if (!string.IsNullOrEmpty(api.displayName))
                 {
-                    format = GetOpenApiSpecFormat(false, isJSON, isVersionThree);
-
                     // download definition
 
                     if (isUrl)


### PR DESCRIPTION
Fixes #567.

If a specific format for the `openApiSpecFormat` property is set to either `OpenApi30_Json` or `OpenApi30_Yaml`, *and* the `displayName` property is also specified, the code tries to download and embed the service contract definition in order to update its `title` property.

This is to workaround an issue (#538) that Azure API Management seemed to not honor the `displayName` but always took that of the `title` property specified in the service contract.

Recently, this issue seems to have been resolved.

Nonetheless, the error reported in #567 is now fixed irrespective of whether the `displayName` is updated or not.
