### PR TITLE
Fixes for ExtractorUtils::GetPolicyContent

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/ExtractorUtils.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/Utilities/ExtractorUtils.cs
@@ -419,9 +419,19 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 if (_policyCache.TryGetValue(key, out string content))
                     return content;
 
-                var filename = policyContent.Split(',')[1].Replace("'", string.Empty).Trim();
+                // if the file name is paramterized, pull out the filename between the single quotes in the second segment
+                var filename = policyContent.Split(',')[1]?.Split("'")[1]?.Trim();
                 var policyFolder = $@"{exc.fileFolder}/policies";
-                var filepath = $@"{Directory.GetCurrentDirectory()}/{policyFolder}/{filename}";
+                // Account for either rooted or non-rooted fileFolder value in extractor params
+                var filepath = string.Empty;
+                if ( Path.IsPathRooted($@"{policyFolder}/{filename}"))
+                    {
+                    filepath = $@"{policyFolder}/{filename}";
+                    }
+                else
+                    {
+                    filepath = $@"{Directory.GetCurrentDirectory()}/{policyFolder}/{filename}";
+                    }
 
                 if (File.Exists(filepath))
                 {


### PR DESCRIPTION
  1. BUG: When policyContent contained a value such as `[concat(parameters('PolicyXMLBaseUrl'), '/insights-apikeys-generate-key-operationPolicy.xml')]`, `)]` became part of the filename
    - FIX:  From the result of the split on ',', split on "'" and use the second segment
    - CONCERNS:  I am not sure of the full realm of possible values, and this fix may be too specific to my situation.
  2. BUG:  When `fileFolder` in extractor params is an absolute path, prepending with CurrentDirectory will not work
    - FIX:  Use Path.IsPathRooted to determine whether to prepend CurrentDirectory
    - CONCERNS:  Will this cover all cases without breaking existing cases?