### PR TITLE
Fix error with json-patch APIs

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/APIExtractor.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
 
         private static string[] ContentTypes()
         {
-            return new string[] { "application/json", "text/json", "application/*+json" };
+            return new string[] { "application/json", "text/json", "application/*+json", "application/json-patch+json" };
         }
 
         private static void AddSchemaDependencyToOperationIfNecessary(string apiName, List<string> operationDependsOn, OperationTemplateRepresentation operationTemplateRepresentation)


### PR DESCRIPTION
Fixes an error that occurs when extracting an API with a PATCH method. For such methods, the contentType was `application/json-patch+json`, which was not detected as a json type format and the `sample` field was not properly escaped.