### PR TITLE
Creator: Allow NamedValues and KeyVault Secrets to be parameterized

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Creator/Models/CreatorConfiguration.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/Models/CreatorConfiguration.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
         public string linkedTemplatesUrlQueryString { get; set; }
         public string baseFileName { get; set; }
         public List<ServiceUrlProperty> serviceUrlParameters { get; set; }
+        public bool paramNamedValue { get; set; }
     }
 
     public class APIVersionSetConfig : APIVersionSetProperties

--- a/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PropertyTemplateCreator.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Creator/TemplateCreators/PropertyTemplateCreator.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
 {
@@ -16,9 +18,35 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                 { ParameterNames.ApimServiceName, new TemplateParameterProperties(){ type = "string" } }
             };
 
+            if (creatorConfig.paramNamedValue)
+            {
+                if (creatorConfig.namedValues.Any(x => x.value != null))
+                {
+                    propertyTemplate.parameters.Add(ParameterNames.NamedValues, new TemplateParameterProperties { type = "object" });
+                }
+
+                if (creatorConfig.namedValues.Any(x => x.keyVault != null))
+                {
+                    propertyTemplate.parameters.Add(ParameterNames.NamedValueKeyVaultSecrets, new TemplateParameterProperties { type = "object" });
+                }
+            }
+
             List<TemplateResource> resources = new List<TemplateResource>();
             foreach (PropertyConfig namedValue in creatorConfig.namedValues)
             {
+                string value = namedValue.value == null ? null
+                    : creatorConfig.paramNamedValue
+                        ? $"[parameters('{ParameterNames.NamedValues}').{ExtractorUtils.GenValidParamName(namedValue.displayName, ParameterPrefix.Property)}]"
+                        : namedValue.value;
+
+                PropertyResourceKeyVaultProperties keyVault = namedValue.keyVault == null ? null
+                    : creatorConfig.paramNamedValue
+                        ? new PropertyResourceKeyVaultProperties
+                        {
+                            secretIdentifier = $"[parameters('{ParameterNames.NamedValueKeyVaultSecrets}').{ExtractorUtils.GenValidParamName(namedValue.displayName, ParameterPrefix.Property)}]"
+                        }
+                        : namedValue.keyVault;
+
                 // create property resource with properties
                 PropertyTemplateResource propertyTemplateResource = new PropertyTemplateResource()
                 {
@@ -28,13 +56,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Create
                     properties = new PropertyResourceProperties()
                     {
                         displayName = namedValue.displayName,
-                        value = namedValue.value,
+                        value = value,
                         secret = namedValue.secret,
                         tags = namedValue.tags,
-                        keyVault = namedValue.keyVault
-
+                        keyVault = keyVault
                     },
-                    dependsOn = new string[] {}
+                    dependsOn = new string[] { }
                 };
                 resources.Add(propertyTemplateResource);
             }


### PR DESCRIPTION
Add support for `paramNamedValue` property on Creator config which will parameterize the named values (normal and key vault) in the ARM templates created by the Creator. 

This makes it possible to generate 1 APIM ARM template that can be deployed to multiple environments and only have to supply different parameters to the ARM deployment instead of having to generate multiple ARM templates for each environment.