### PR TITLE
[Extractor] Fix DependsOn references for siblings when ApiTagResource and ProductApiResource calls return empty lists

### DIFF
--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/ProductAPIExtractor.cs
@@ -88,9 +88,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 string[] dependsOn = new string[] {};
                 foreach (string apiName in multipleApiNames)
                 {
-                    templateResources.AddRange(await GenerateSingleProductAPIResourceAsync(apiName, exc, dependsOn));
-                    string apiProductName = templateResources.Last().name.Split('/', 3)[1];
-                    dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiProductName}', '{apiName}')]" };
+                    List<TemplateResource> productResources = await GenerateSingleProductAPIResourceAsync(apiName, exc, dependsOn);
+
+                    if (productResources.Count > 0)
+                    {
+                        templateResources.AddRange(productResources);
+                        string apiProductName = templateResources.Last().name.Split('/', 3)[1];
+                        dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiProductName}', '{apiName}')]" };
+                    }
                 }
             }
             // when extract all APIs and generate one master template
@@ -103,10 +108,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 foreach (JToken oApi in oApis)
                 {
                     string apiName = ((JValue)oApi["name"]).Value.ToString();
-                    templateResources.AddRange(await GenerateSingleProductAPIResourceAsync(apiName, exc, dependsOn));
 
-                    if (templateResources.Count > 0)
+                    List<TemplateResource> productResources = await GenerateSingleProductAPIResourceAsync(apiName, exc, dependsOn);
+                    if (productResources.Count > 0)
                     {
+                        templateResources.AddRange(productResources);
                         string apiProductName = templateResources.Last().name.Split('/', 3)[1];
                         dependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiProductName}', '{apiName}')]" };
                     }

--- a/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
+++ b/src/APIM_ARMTemplate/apimtemplate/Extractor/EntityExtractors/TagAPIExtractor.cs
@@ -126,10 +126,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 string[] dependsOn = new string[] {};
                 foreach (string apiName in multipleApiNames)
                 {
-                    templateResources.AddRange(await GenerateSingleAPITagResourceAsync(apiName, exc, dependsOn));
-
-                    if (templateResources.Count > 0)
+                    List<TemplateResource> tagResources = await GenerateSingleAPITagResourceAsync(apiName, exc, dependsOn);
+                    if (tagResources.Count > 0)
                     {
+                        templateResources.AddRange(tagResources);
 
                         // Extract the tag name from the last resource
                         string[] lastTagName = templateResources.Last().name.Replace("')]", "").Split('/');
@@ -156,9 +156,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extract
                 foreach (JToken oApi in oApis)
                 {
                     string apiName = ((JValue)oApi["name"]).Value.ToString();
-                    templateResources.AddRange(await GenerateSingleAPITagResourceAsync(apiName, exc, dependsOn));
-                    if (templateResources.Count > 0)
+
+                    List<TemplateResource> tagResources = await GenerateSingleAPITagResourceAsync(apiName, exc, dependsOn);
+                    if (tagResources.Count > 0)
                     {
+                        templateResources.AddRange(tagResources);
+
                         // Extract the tag name from the last resource
                         string[] lastTagName = templateResources.Last().name.Replace("')]", "").Split('/');
                         if (lastTagName.Length > 3)


### PR DESCRIPTION
Calls to GenerateSingleProductAPIResourceAsync and GenerateSingleAPITagResourceAsync can return empty resource lists which will not be added to the template, but the extractor keeps a running record of the last resource to set the dependsOn value.

This results in dependsOn values that do not exist in the template and cause validation failures.