### PR TITLE
disable PR trigger for scheduled pipeline

### DIFF
--- a/.azure-pipelines/scheduled-build.yml
+++ b/.azure-pipelines/scheduled-build.yml
@@ -13,3 +13,6 @@ schedules:
   branches:
     include:
     - master
+
+# no PR triggers
+pr: none


### PR DESCRIPTION
Validation on the PR is made using separate [PR-build](https://github.com/Azure/azure-api-management-devops-resource-kit/blob/master/.azure-pipelines/pr-build.yml), not the [scheduled one](https://github.com/Azure/azure-api-management-devops-resource-kit/blob/master/.azure-pipelines/scheduled-build.yml)