### PR TITLE
serialization fixes after refactoring + entry point descriptions added

### DIFF
--- a/src/ArmTemplates/Commands/Configurations/CreateConsoleAppConfiguration.cs
+++ b/src/ArmTemplates/Commands/Configurations/CreateConsoleAppConfiguration.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configu
     [Verb(GlobalConstants.CreateName, HelpText = GlobalConstants.CreateDescription)]
     public class CreateConsoleAppConfiguration
     {
+        [Option(longName: "configFile", HelpText = "Config YAML file location", Required = true)]
+        public string ConfigFile { get; set; }
+
         [Option(longName: "appInsightsInstrumentationKey", HelpText = "AppInsights intrumentationkey")]
         public string AppInsightsInstrumentationKey { get; set; }
 
@@ -23,9 +26,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configu
 
         [Option(longName: "apimNameValue", HelpText = "Apim Name Value")]
         public string ApimNameValue { get; set; }
-
-        [Option(longName: "configFile", HelpText = "Config YAML file location")]
-        public string ConfigFile { get; set; }
 
         [Option(longName: "backendUrlConfigFile", HelpText = "Backend url json file location")]
         public string BackendUrlConfigFile { get; set; }

--- a/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
+++ b/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
@@ -10,16 +10,16 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configu
         [Option(longName: "extractorConfig", HelpText = "Config file of the extractor")]
         public string ExtractorConfig { get; set; }
 
-        [Option(longName: "sourceApimName", HelpText = "Source API Management name")]
+        [Option(longName: "sourceApimName", HelpText = "Source API Management name", Required = true)]
         public string SourceApimName { get; set; }
 
-        [Option(longName: "destinationApimName", HelpText = "Destination API Management name")]
+        [Option(longName: "destinationApimName", HelpText = "Destination API Management name", Required = true)]
         public string DestinationApimName { get; set; }
 
-        [Option(longName: "resourceGroup", HelpText = "Resource Group name")]
+        [Option(longName: "resourceGroup", HelpText = "Resource Group name", Required = true)]
         public string ResourceGroup { get; set; }
 
-        [Option(longName: "fileFolder", HelpText = "ARM Template files folder")]
+        [Option(longName: "fileFolder", HelpText = "ARM Template files folder", Required = true)]
         public string FileFolder { get; set; }
 
         [Option(longName: "apiName", HelpText = "Single API name")]

--- a/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
+++ b/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
@@ -10,16 +10,16 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configu
         [Option(longName: "extractorConfig", HelpText = "Config file of the extractor")]
         public string ExtractorConfig { get; set; }
 
-        [Option(longName: "sourceApimName", HelpText = "Source API Management name", Required = true)]
+        [Option(longName: "sourceApimName", HelpText = "Source API Management name")]
         public string SourceApimName { get; set; }
 
-        [Option(longName: "destinationApimName", HelpText = "Destination API Management name", Required = true)]
+        [Option(longName: "destinationApimName", HelpText = "Destination API Management name")]
         public string DestinationApimName { get; set; }
 
-        [Option(longName: "resourceGroup", HelpText = "Resource Group name", Required = true)]
+        [Option(longName: "resourceGroup", HelpText = "Resource Group name")]
         public string ResourceGroup { get; set; }
 
-        [Option(longName: "fileFolder", HelpText = "ARM Template files folder", Required = true)]
+        [Option(longName: "fileFolder", HelpText = "ARM Template files folder")]
         public string FileFolder { get; set; }
 
         [Option(longName: "apiName", HelpText = "Single API name")]

--- a/src/ArmTemplates/Common/Extensions/JsonExtensions.cs
+++ b/src/ArmTemplates/Common/Extensions/JsonExtensions.cs
@@ -21,5 +21,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extension
         public static string Serialize<T>(this T item) => JsonConvert.SerializeObject(item, DefaultJsonSerializationSettings);
 
         public static T Deserialize<T>(this string serializedItem) => JsonConvert.DeserializeObject<T>(serializedItem, DefaultJsonSerializationSettings);
+
+        public static T Deserialize<T>(this string serializedItem, JsonConverter jsonConverter) => JsonConvert.DeserializeObject<T>(serializedItem, converters: jsonConverter);
     }
 }

--- a/src/ArmTemplates/Common/FileHandlers/FileReader.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileReader.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using YamlDotNet.Serialization;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Creator.Models;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configurations;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandlers
 {
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
                         StringWriter writer = new StringWriter();
                         jsonSerializer.Serialize(writer, deserializedYaml);
                         string jsonText = writer.ToString();
-                        CreatorConfig yamlObject = JsonConvert.DeserializeObject<CreatorConfig>(jsonText);
+                        CreatorConfig yamlObject = jsonText.Deserialize<CreatorConfig>();
                         return yamlObject;
                     }
                 }
@@ -54,7 +55,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
                     jsonSerializer.Serialize(writer, deserializedYaml);
                     string jsonText = writer.ToString();
                     // deserialize CreatorConfig from json string
-                    CreatorConfig yamlObject = JsonConvert.DeserializeObject<CreatorConfig>(jsonText);
+                    CreatorConfig yamlObject = jsonText.Deserialize<CreatorConfig>();
                     return yamlObject;
                 }
             }
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
             using (StreamReader r = new StreamReader(extractorJsonPath))
             {
                 string extractorJson = r.ReadToEnd();
-                ExtractorConsoleAppConfiguration extractorConfig = JsonConvert.DeserializeObject<ExtractorConsoleAppConfiguration>(extractorJson);
+                ExtractorConsoleAppConfiguration extractorConfig = extractorJson.Deserialize<ExtractorConsoleAppConfiguration>();
                 return extractorConfig;
             }
         }
@@ -110,7 +111,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
         {
             try
             {
-                object deserializedFileContents = JsonConvert.DeserializeObject<object>(fileContents);
+                object deserializedFileContents = fileContents.Deserialize<object>();
                 return true;
             }
             catch (Exception)

--- a/src/ArmTemplates/Common/FileHandlers/FileWriter.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileWriter.cs
@@ -27,13 +27,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
 
         public static void WriteJSONToFile(object template, string location)
         {
-            // writes json object to provided location
-            string jsonString = JsonConvert.SerializeObject(template,
-                            Formatting.Indented,
-                            new JsonSerializerSettings
-                            {
-                                NullValueHandling = NullValueHandling.Ignore
-                            });
+            var jsonString = template.Serialize();
             File.WriteAllText(location, jsonString);
         }
 

--- a/src/ArmTemplates/Common/FileHandlers/OpenAPISpecReader.cs
+++ b/src/ArmTemplates/Common/FileHandlers/OpenAPISpecReader.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
+using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Net.Http;
@@ -8,7 +9,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
 {
     public class OpenAPISpecReader
     {
-        public async Task<bool> isJSONOpenAPISpecVersionThreeAsync(string openApiSpecFileLocation)
+        public async Task<bool> IsJSONOpenAPISpecVersionThreeAsync(string openApiSpecFileLocation)
         {
             // determine whether file location is local file path or remote url and read content
             Uri uriResult;
@@ -21,7 +22,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
                 if (response.IsSuccessStatusCode)
                 {
                     string fileContents = await response.Content.ReadAsStringAsync();
-                    OpenAPISpecWithVersion openAPISpecWithVersion = JsonConvert.DeserializeObject<OpenAPISpecWithVersion>(fileContents);
+                    OpenAPISpecWithVersion openAPISpecWithVersion = fileContents.Deserialize<OpenAPISpecWithVersion>();
                     // OASv3 has the property 'openapi' but not the property 'swagger'
                     return openAPISpecWithVersion.Swagger != null ? false : true;
                 }
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
             else
             {
                 string fileContents = File.ReadAllText(openApiSpecFileLocation);
-                OpenAPISpecWithVersion openAPISpecWithVersion = JsonConvert.DeserializeObject<OpenAPISpecWithVersion>(fileContents);
+                OpenAPISpecWithVersion openAPISpecWithVersion = fileContents.Deserialize<OpenAPISpecWithVersion>();
                 // OASv3 has the property 'openapi' but not the property 'swagger'
                 return openAPISpecWithVersion.Swagger != null ? false : true;
             }

--- a/src/ArmTemplates/Creator/TemplateCreators/APITemplateCreator.cs
+++ b/src/ArmTemplates/Creator/TemplateCreators/APITemplateCreator.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Creator.Template
                     if (isJSON == true)
                     {
                         var openAPISpecReader = new OpenAPISpecReader();
-                        isVersionThree = await openAPISpecReader.isJSONOpenAPISpecVersionThreeAsync(api.openApiSpec);
+                        isVersionThree = await openAPISpecReader.IsJSONOpenAPISpecVersionThreeAsync(api.openApiSpec);
                     }
                     format = GetOpenApiSpecFormat(isUrl, isJSON, isVersionThree);
                 }

--- a/src/ArmTemplates/Creator/Utilities/CreatorApiBackendUrlUpdater.cs
+++ b/src/ArmTemplates/Creator/Utilities/CreatorApiBackendUrlUpdater.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandlers;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Creator.Models;
 using Newtonsoft.Json;
@@ -17,7 +18,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Creator.Utilitie
             //if the file is json file
             if (fileReader.IsJSON(backendurlConfigContent))
             {
-                List<BackendUrlsConfig> backendUrls = JsonConvert.DeserializeObject<List<BackendUrlsConfig>>(backendurlConfigContent);
+                List<BackendUrlsConfig> backendUrls = backendurlConfigContent.Deserialize<List<BackendUrlsConfig>>();
 
                 foreach (APIConfig aPIConfig in creatorConfig.apis)
                 {

--- a/src/ArmTemplates/Creator/Utilities/OpenApi.cs
+++ b/src/ArmTemplates/Creator/Utilities/OpenApi.cs
@@ -1,5 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using YamlDotNet.Serialization;
@@ -26,9 +28,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Creator.Utilitie
             }
             else
             {
-                this.definition_ = JsonConvert.DeserializeObject<Dictionary<string, object>>(definition, new JsonDictionaryConverter());
+                this.definition_ = definition.Deserialize<Dictionary<string, object>>(new JsonDictionaryConverter());
             }
-        }
+        }   
         public OpenApi SetTitle(string title)
         {
             if (this.format_ == "openapi")
@@ -53,7 +55,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Creator.Utilitie
             else
             {
                 // include StringEscaping to ensure single quotes are escaped
-                return JsonConvert.SerializeObject(this.definition_, settings: new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml });
+                return JsonConvert.SerializeObject(this.definition_, settings: new JsonSerializerSettings { 
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    StringEscapeHandling = StringEscapeHandling.EscapeHtml 
+                });
             }
         }
 

--- a/src/ArmTemplates/Creator/Utilities/OpenApi.cs
+++ b/src/ArmTemplates/Creator/Utilities/OpenApi.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Creator.Utilitie
             {
                 this.definition_ = definition.Deserialize<Dictionary<string, object>>(new JsonDictionaryConverter());
             }
-        }   
+        }
+
         public OpenApi SetTitle(string title)
         {
             if (this.format_ == "openapi")

--- a/src/ArmTemplates/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/APIExtractor.cs
@@ -165,9 +165,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             string requestUrl = string.Format("{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}",
                BaseUrl, azSubId, resourceGroupName, apiManagementName, apiName, GlobalConstants.ApiVersion);
 
-            string apiDetails = await this.CallApiManagementAsync(azToken, requestUrl);
-            JObject oApiDetails = JObject.Parse(apiDetails);
-            APITemplateResource apiResource = JsonConvert.DeserializeObject<APITemplateResource>(apiDetails);
+            string apiDetails = await this.CallApiManagementAsync(azToken, requestUrl);            
+            APITemplateResource apiResource = apiDetails.Deserialize<APITemplateResource>();
             return apiResource.Properties.ServiceUrl;
         }
 

--- a/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                     string backend = await this.GetBackendDetailsAsync(apimname, resourceGroup, backendName);
 
                     // convert returned backend to template resource class
-                    BackendTemplateResource backendTemplateResource = JsonConvert.DeserializeObject<BackendTemplateResource>(backend);
+                    BackendTemplateResource backendTemplateResource = backend.Deserialize<BackendTemplateResource>();
                     backendTemplateResource.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{backendName}')]";
                     backendTemplateResource.ApiVersion = GlobalConstants.ApiVersion;
 
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                             string backend = await this.GetBackendDetailsAsync(apimname, resourceGroup, backendName);
 
                             // convert returned backend to template resource class
-                            BackendTemplateResource backendTemplateResource = JsonConvert.DeserializeObject<BackendTemplateResource>(backend);
+                            BackendTemplateResource backendTemplateResource = backend.Deserialize<BackendTemplateResource>();
 
                             // we have already checked if the named value is used in a policy, we just need to confirm if the backend is referenced by this single api within the policy file
                             // this is why an empty named values must be passed to this method for validation

--- a/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 string fullLoggerResource = await this.GetLoggerDetailsAsync(extractorParameters.SourceApimName, extractorParameters.ResourceGroup, loggerName);
 
                 // convert returned logger to template resource class
-                LoggerTemplateResource loggerResource = JsonConvert.DeserializeObject<LoggerTemplateResource>(fullLoggerResource);
+                LoggerTemplateResource loggerResource = fullLoggerResource.Deserialize<LoggerTemplateResource>();
                 loggerResource.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{loggerName}')]";
                 loggerResource.Type = ResourceTypeConstants.Logger;
                 loggerResource.ApiVersion = GlobalConstants.ApiVersion;

--- a/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -566,7 +566,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                     if (propertyResources.Count(item => item.Name.Contains(propertyName)) > 0)
                     {
                         string fullPropertyResource = await pExc.GetPropertyDetailsAsync(extractorParameters.SourceApimName, extractorParameters.ResourceGroup, propertyName);
-                        PropertyTemplateResource propertyTemplateResource = JsonConvert.DeserializeObject<PropertyTemplateResource>(fullPropertyResource);
+                        PropertyTemplateResource propertyTemplateResource = fullPropertyResource.Deserialize<PropertyTemplateResource>();
 
                         //Only add the property if it is not controlled by keyvault
                         if (propertyTemplateResource?.Properties.keyVault == null)
@@ -598,7 +598,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                     if (propertyResources.Count(item => item.Name.Contains(propertyName)) > 0)
                     {
                         string fullPropertyResource = await pExc.GetPropertyDetailsAsync(extractorParameters.SourceApimName, extractorParameters.ResourceGroup, propertyName);
-                        PropertyTemplateResource propertyTemplateResource = JsonConvert.DeserializeObject<PropertyTemplateResource>(fullPropertyResource);
+                        PropertyTemplateResource propertyTemplateResource = fullPropertyResource.Deserialize<PropertyTemplateResource>();
                         if (propertyTemplateResource?.Properties.keyVault != null)
                         {
                             string propertyValue = propertyTemplateResource.Properties.keyVault.secretIdentifier;

--- a/src/ArmTemplates/Extractor/EntityExtractors/PropertyExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/PropertyExtractor.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 string fullPropertyResource = await this.GetPropertyDetailsAsync(extractorParameters.SourceApimName, extractorParameters.ResourceGroup, propertyName);
 
                 // convert returned named value to template resource class
-                PropertyTemplateResource propertyTemplateResource = JsonConvert.DeserializeObject<PropertyTemplateResource>(fullPropertyResource);
+                PropertyTemplateResource propertyTemplateResource = fullPropertyResource.Deserialize<PropertyTemplateResource>();
                 propertyTemplateResource.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{propertyName}')]";
                 propertyTemplateResource.Type = ResourceTypeConstants.Property;
                 propertyTemplateResource.ApiVersion = GlobalConstants.ApiVersion;

--- a/src/README.md
+++ b/src/README.md
@@ -1,10 +1,21 @@
 # Table of Contents
 
-1. [ Creator ](#Creator)
+1. [Running ArmTemplates Application](#running-armTemplates-application)
+2. [ Creator ](#Creator)
     * [Create the Config File](#creator1)
     * [Running the Creator](#creator2)
-2. [ Extractor ](#Extractor)
+3. [ Extractor ](#Extractor)
     * [Running the Extractor](#running-the-extractor)
+
+# Running ArmTemplates Application
+
+Follow this guide for manually building and running the application
+1. git clone repository
+2. navigate to repo root
+3. build application using `dotnet build src/ArmTemplates/ArmTemplates.csproj` (netcore3.1 must be installed)
+4. navigate to built binaries using `cd .\src\ArmTemplates\bin\Debug\netcoreapp3.1\`
+5. run ` dotnet .\ArmTemplates.dll --help` to view all available commands
+6. Investigate possible commands to run and choose desired
 
 # Creator
 
@@ -318,7 +329,7 @@ serviceUrlParameters:
 Below are the steps to run the Creator from the source code:
 
 - Clone this repository and restore its packages using ```dotnet restore```
-- Navigate to {path_to_folder}/src/ARMTemplates directory
+- Navigate to {repo root}/src/ARMTemplates directory
 - Run the following command:
 ```dotnet run create --configFile CONFIG_YAML_FILE_LOCATION ```
 - Run the following command to pass apim Name as a parameter:
@@ -363,7 +374,7 @@ To be able to run the Extractor, you would first need to [install the Azure CLI]
 
 ## Running the Extractor
 Below are the steps to run the Extractor from the source code:
-- Clone this repository and navigate to {path_to_folder}/src/ARMTemplates
+- Clone this repository and navigate to {repo root}/src/ARMTemplates
 - Restore its packages using ```dotnet restore```
 - Make sure you have signed in using Azure CLI and have switched to the subscription containing the API Management instance from which the configurations will be extracted. 
 ```

--- a/tests/ArmTemplates.Tests/Common/FileHandlerTests/OpenAPISpecReaderTests.cs
+++ b/tests/ArmTemplates.Tests/Common/FileHandlerTests/OpenAPISpecReaderTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Common.Fil
             OpenAPISpecReader openAPISpecReader = new OpenAPISpecReader();
 
             // act
-            bool shouldOutputVersionTwo = await openAPISpecReader.isJSONOpenAPISpecVersionThreeAsync(string.Concat(this.openAPISpecFolder, "swaggerPetstore.json"));
-            bool shouldOutputVersionThree = await openAPISpecReader.isJSONOpenAPISpecVersionThreeAsync(string.Concat(this.openAPISpecFolder, "swaggerPetstorev3.json"));
+            bool shouldOutputVersionTwo = await openAPISpecReader.IsJSONOpenAPISpecVersionThreeAsync(string.Concat(this.openAPISpecFolder, "swaggerPetstore.json"));
+            bool shouldOutputVersionThree = await openAPISpecReader.IsJSONOpenAPISpecVersionThreeAsync(string.Concat(this.openAPISpecFolder, "swaggerPetstorev3.json"));
 
             // assert
             Assert.False(shouldOutputVersionTwo);


### PR DESCRIPTION
- Fixed serialization for creator and non-refactored code, so that it is working with camel-case serialization.
- Provided full description of errors\commands and etc. Below are examples:

No parameters passed
![image](https://user-images.githubusercontent.com/31598696/158991913-fb4acc0f-56f3-4d36-a9ae-c766d6dd6b98.png)

`extract` passed with no parameters
![image](https://user-images.githubusercontent.com/31598696/158992088-05691537-b76e-4589-9c29-a79b6f7d4aab.png)

`create` passed with no parameters
![image](https://user-images.githubusercontent.com/31598696/158992352-2024ba48-370d-4991-b4d6-57ef1ca05ec3.png)
