### PR TITLE
Documentation update for changed Project Structure in Refactoring PR

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -353,7 +353,7 @@ Additionaly, the Creator can also be made available as a global [dotnet CLI tool
 
 ```
 dotnet pack -c Release
-dotnet tool install -g --add-source .\bin\Release apimtemplate
+dotnet tool install -g --add-source .\bin\Release ArmTemplates
 ```
 
 The Creator tool is now available anywhere on the command-line:


### PR DESCRIPTION
Documentation Update:
Due to the project structure changes in Refactoring PR #649 the instructions for installing the creator/extractor as a global command line tool break. Users will find the error: 
```
error NU1101: Unable to find package apim-template.
```

