### PR TITLE
Fixes after all-apis-extractor run

### DIFF
--- a/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
         readonly IProductApisExtractor productApisExtractor;
         readonly IProductExtractor productExtractor;
         readonly IPropertyExtractor propertyExtractor;
-        readonly ITagApiExtractor apiTagExtractor;
+        readonly ITagApiExtractor tagApiExtractor;
         readonly ITagExtractor tagExtractor;
         readonly IGroupExtractor groupExtractor;
         readonly IApiRevisionExtractor apiRevisionExtractor;
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             IProductApisExtractor productApisExtractor,
             IProductExtractor productExtractor,
             IPropertyExtractor propertyExtractor,
-            ITagApiExtractor apiTagExtractor,
+            ITagApiExtractor tagApiExtractor,
             ITagExtractor tagExtractor,
             IGroupExtractor groupExtractor,
             IApiRevisionExtractor apiRevisionExtractor,
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             this.productApisExtractor = productApisExtractor;
             this.propertyExtractor = propertyExtractor;
             this.productExtractor = productExtractor;
-            this.apiTagExtractor = apiTagExtractor;
+            this.tagApiExtractor = tagApiExtractor;
             this.tagExtractor = tagExtractor;
             this.groupExtractor = groupExtractor;
             this.apiRevisionExtractor = apiRevisionExtractor;
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             IProductApisExtractor productApisExtractor = null,
             IProductExtractor productExtractor = null,
             IPropertyExtractor propertyExtractor = null,
-            ITagApiExtractor apiTagExtractor = null,
+            ITagApiExtractor tagApiExtractor = null,
             ITagExtractor tagExtractor = null,
             IGroupExtractor groupExtractor = null,
             IApiRevisionExtractor apiRevisionExtractor = null,
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 productApisExtractor,
                 productExtractor,
                 propertyExtractor,
-                apiTagExtractor,
+                tagApiExtractor,
                 tagExtractor,
                 groupExtractor,
                 apiRevisionExtractor,
@@ -413,30 +413,30 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
         }
 
         /// <summary>
-        /// Generates api-tag templates in the desired folder
+        /// Generates tag-api templates in the desired folder
         /// </summary>
-        /// <param name="singleApiName">name of API to load api-tag from</param>
-        /// <param name="multipleApiNames">multiple API names to load api-tag from</param>
+        /// <param name="singleApiName">name of API to load tag-api from</param>
+        /// <param name="multipleApiNames">multiple API names to load tag-api from</param>
         /// <param name="baseFilesGenerationDirectory">name of base folder where to save output files</param>
-        /// <returns>generated api-tag template</returns>
-        public async Task<Template<TagApiTemplateResources>> GenerateApiTagTemplateAsync(
+        /// <returns>generated tag-api template</returns>
+        public async Task<Template<TagApiTemplateResources>> GenerateTagApiTemplateAsync(
             string singleApiName,
             List<string> multipleApiNames,
             string baseFilesGenerationDirectory)
         {
-            this.logger.LogInformation("Started generation of api-tag template...");
+            this.logger.LogInformation("Started generation of tag-api template...");
 
-            var apiTagTemplate = await this.apiTagExtractor.GenerateApiTagsTemplateAsync(singleApiName, multipleApiNames, this.extractorParameters);
+            var apiTagTemplate = await this.tagApiExtractor.GenerateApiTagsTemplateAsync(singleApiName, multipleApiNames, this.extractorParameters);
 
             if (apiTagTemplate?.HasResources() == true)
             {
                 await FileWriter.SaveAsJsonAsync(
                     apiTagTemplate,
                     directory: baseFilesGenerationDirectory,
-                    fileName: this.extractorParameters.FileNames.ApiTags);
+                    fileName: this.extractorParameters.FileNames.TagApi);
             }
 
-            this.logger.LogInformation("Finished generation of api-tag template...");
+            this.logger.LogInformation("Finished generation of tag-api template...");
             return apiTagTemplate;
         }
 
@@ -703,7 +703,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             var apiVersionSetTemplate = await this.GenerateApiVersionSetTemplateAsync(singleApiName, baseFilesGenerationDirectory, apiTemplate.TypedResources.Apis);
             var authorizationServerTemplate = await this.GenerateAuthorizationServerTemplateAsync(singleApiName, baseFilesGenerationDirectory, apiTemplate.TypedResources.Apis);
             var tagTemplate = await this.GenerateTagTemplateAsync(singleApiName, apiTemplate.TypedResources, productTemplate.TypedResources, baseFilesGenerationDirectory);
-            var apiTagTemplate = await this.GenerateApiTagTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
+            var apiTagTemplate = await this.GenerateTagApiTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
             await this.GenerateGroupsTemplateAsync(baseFilesGenerationDirectory);
             await this.GenerateGatewayTemplateAsync(singleApiName, baseFilesGenerationDirectory);
 

--- a/src/ArmTemplates/Common/Extensions/ParameterNamingHelper.cs
+++ b/src/ArmTemplates/Common/Extensions/ParameterNamingHelper.cs
@@ -9,7 +9,17 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extension
 
         public static string GenerateValidParameterName(string apiName, string prefix)
         {
+            if (string.IsNullOrEmpty(apiName))
+            {
+                return string.Empty;
+            }
+
             var validApiName = ExcludeOtherFromLettersAndDigitsRegex.Replace(apiName, string.Empty);
+
+            if (string.IsNullOrEmpty(validApiName))
+            {
+                return string.Empty;
+            }
 
             if (char.IsDigit(validApiName.First()))
             {

--- a/src/ArmTemplates/Common/FileHandlers/FileNameGenerator.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileNameGenerator.cs
@@ -29,7 +29,7 @@
                 ProductAPIs = $@"{baseFileName}productAPIs.template.json",
                 Gateway = $@"{baseFileName}gateways.template.json",
                 GatewayApi = $@"{baseFileName}gateways-apis.template.json",
-                ApiTags = $@"{baseFileName}apiTags.template.json",
+                TagApi = $@"{baseFileName}apiTags.template.json",
                 Parameters = $@"\{baseFileName}parameters.json",
                 LinkedMaster = $@"\{baseFileName}master.template.json",
                 Apis = "/Apis",

--- a/src/ArmTemplates/Common/FileHandlers/FileNames.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileNames.cs
@@ -22,7 +22,7 @@
 
         public string Groups { get; set; }
 
-        public string ApiTags { get; set; }
+        public string TagApi { get; set; }
 
         public string Gateway { get; set; }
 

--- a/src/ArmTemplates/Extractor/EntityExtractors/APIVersionSetExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/APIVersionSetExtractor.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             foreach (var apiVersionSet in apiVersionSets)
             {
                 // only extract the product if this is a full extraction, or in the case of a single api, if it is found in products associated with the api
-                if (string.IsNullOrEmpty(singleApiName) || apiTemplateResources.FirstOrDefault(api => 
+                if (string.IsNullOrEmpty(singleApiName) || apiTemplateResources.Any(api => 
                         api.Properties.ApiVersionSetId != null && 
-                        api.Properties.ApiVersionSetId.Contains(apiVersionSet.Name)) != null)
+                        api.Properties.ApiVersionSetId.Contains(apiVersionSet.Name)))
                 {
                     this.logger.LogDebug("Found '{0}' api-version-set", apiVersionSet.Name);
 

--- a/src/ArmTemplates/Extractor/EntityExtractors/APIVersionSetExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/APIVersionSetExtractor.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             foreach (var apiVersionSet in apiVersionSets)
             {
                 // only extract the product if this is a full extraction, or in the case of a single api, if it is found in products associated with the api
-                if (string.IsNullOrEmpty(singleApiName) || apiTemplateResources.SingleOrDefault(api => 
+                if (string.IsNullOrEmpty(singleApiName) || apiTemplateResources.FirstOrDefault(api => 
                         api.Properties.ApiVersionSetId != null && 
                         api.Properties.ApiVersionSetId.Contains(apiVersionSet.Name)) != null)
                 {

--- a/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
 using System.Linq;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Logger;
@@ -11,17 +10,21 @@ using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtr
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Policy;
-using Microsoft.Azure.Management.ApiManagement.Models;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors
 {
     public class LoggerExtractor : EntityExtractorBase, ILoggerExtractor
     {
+        readonly ILogger<LoggerExtractor> logger;
         readonly ITemplateBuilder templateBuilder;
 
-        public LoggerExtractor(ITemplateBuilder templateBuilder)
+        public LoggerExtractor(
+            ILogger<LoggerExtractor> logger,
+            ITemplateBuilder templateBuilder)
         {
+            this.logger = logger;
             this.templateBuilder = templateBuilder;
         }
 
@@ -98,7 +101,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                             isReferencedInPolicy = true;
                         }
                     }
-                    string validApiName = ParameterNamingHelper.GenerateValidParameterName(singleApiName, ParameterPrefix.Api);
+
+                    string validApiName = ParameterNamingHelper.GenerateValidParameterName(loggerName, ParameterPrefix.Api);
                     if (extractorParameters.ParameterizeApiLoggerId && apiLoggerId.ContainsKey(validApiName))
                     {
                         object diagnosticObj = apiLoggerId[validApiName];

--- a/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -17,14 +17,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 {
     public class LoggerExtractor : EntityExtractorBase, ILoggerExtractor
     {
-        readonly ILogger<LoggerExtractor> logger;
         readonly ITemplateBuilder templateBuilder;
 
-        public LoggerExtractor(
-            ILogger<LoggerExtractor> logger,
-            ITemplateBuilder templateBuilder)
+        public LoggerExtractor(ITemplateBuilder templateBuilder)
         {
-            this.logger = logger;
             this.templateBuilder = templateBuilder;
         }
 
@@ -83,7 +79,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 loggerResource.ApiVersion = GlobalConstants.ApiVersion;
                 loggerResource.Scale = null;
 
-                if (singleApiName == null)
+                if (string.IsNullOrEmpty(singleApiName))
                 {
                     // if the user is extracting all apis, extract all the loggers
                     Console.WriteLine("'{0}' Logger found", loggerName);
@@ -102,7 +98,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                         }
                     }
 
-                    string validApiName = ParameterNamingHelper.GenerateValidParameterName(loggerName, ParameterPrefix.Api);
+                    string validApiName = ParameterNamingHelper.GenerateValidParameterName(singleApiName, ParameterPrefix.Api);
                     if (extractorParameters.ParameterizeApiLoggerId && apiLoggerId.ContainsKey(validApiName))
                     {
                         object diagnosticObj = apiLoggerId[validApiName];

--- a/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             // apiTags
             if (apiTagsTemplate != null && apiTagsTemplate.Resources.Count() != 0)
             {
-                string apiTagsUri = this.GenerateLinkedTemplateUri(extractorParameters.LinkedTemplatesUrlQueryString, extractorParameters.LinkedTemplatesSasToken, fileNames.ApiTags);
+                string apiTagsUri = this.GenerateLinkedTemplateUri(extractorParameters.LinkedTemplatesUrlQueryString, extractorParameters.LinkedTemplatesSasToken, fileNames.TagApi);
                 resources.Add(this.CreateLinkedMasterTemplateResource("apiTagsTemplate", apiTagsUri, apiTagDependsOn.ToArray()));
             }
             Console.WriteLine("Master template generated");

--- a/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
@@ -62,10 +62,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 var productOriginalName = productTemplateResource.Name;
 
                 productTemplateResource.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{productOriginalName}')]";
-                productTemplateResource.ApiVersion = GlobalConstants.ApiVersion;
+                productTemplateResource.ApiVersion = GlobalConstants.ApiVersion;                
 
                 // only extract the product if this is a full extraction, or in the case of a single api, if it is found in products associated with the api
-                if (singleApiName == null || productApiTemplateResources.SingleOrDefault(p => p.Name.Contains($"/{productOriginalName}/")) != null)
+                if (singleApiName == null || productApiTemplateResources.FirstOrDefault(p => p.Name.Contains($"/{productOriginalName}/")) is not null)
                 {
                     this.logger.LogDebug("'{0}' product found", productOriginalName);
                     productsTemplate.TypedResources.Products.Add(productTemplateResource);

--- a/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 var productOriginalName = productTemplateResource.Name;
 
                 productTemplateResource.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{productOriginalName}')]";
-                productTemplateResource.ApiVersion = GlobalConstants.ApiVersion;                
+                productTemplateResource.ApiVersion = GlobalConstants.ApiVersion;
 
                 // only extract the product if this is a full extraction, or in the case of a single api, if it is found in products associated with the api
                 if (singleApiName == null || productApiTemplateResources.FirstOrDefault(p => p.Name.Contains($"/{productOriginalName}/")) is not null)

--- a/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 productTemplateResource.ApiVersion = GlobalConstants.ApiVersion;
 
                 // only extract the product if this is a full extraction, or in the case of a single api, if it is found in products associated with the api
-                if (singleApiName == null || productApiTemplateResources.FirstOrDefault(p => p.Name.Contains($"/{productOriginalName}/")) is not null)
+                if (singleApiName == null || productApiTemplateResources.Any(p => p.Name.Contains($"/{productOriginalName}/")))
                 {
                     this.logger.LogDebug("'{0}' product found", productOriginalName);
                     productsTemplate.TypedResources.Products.Add(productTemplateResource);

--- a/src/ArmTemplates/Extractor/EntityExtractors/TagAPIExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/TagAPIExtractor.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             this.templateBuilder = templateBuilder;
 
             this.tagClient = tagClient;
+            this.apisClient = apisClient;
         }
 
         public async Task<Template<TagApiTemplateResources>> GenerateApiTagsTemplateAsync(

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/TagApiExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/TagApiExtractorTests.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------
+//  <copyright file="TagApiExtractorTests.cs" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+//  </copyright>
+// --------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Castle.Core.Internal;
+using FluentAssertions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Scenarios
+{
+    [Trait("Category", "Tag Api Extraction")]
+    public class TagApiExtractorTests : ExtractorMockerWithOutputTestsBase
+    {
+        public TagApiExtractorTests() : base("tag-api-tests")
+        {
+        }
+
+        [Fact]
+        public async Task GenerateTagApiTemplates_ProperlyLaysTheInformation()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateTagApiTemplates_ProperlyLaysTheInformation));
+
+            var extractorConfig = this.GetMockedExtractorConsoleAppConfiguration(
+                splitApis: false,
+                apiVersionSetName: string.Empty,
+                multipleApiNames: string.Empty,
+                includeAllRevisions: false);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var mockedTagClient = MockTagClient.GetMockedApiClientWithDefaultValues();
+            var mockedApiClient = MockApisClient.GetMockedApiClientWithDefaultValues();
+            var tagApiExtractor = new TagApiExtractor(
+                this.GetTestLogger<TagApiExtractor>(), 
+                new TemplateBuilder(),
+                mockedApiClient,
+                mockedTagClient);
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                tagApiExtractor: tagApiExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            // act
+            var tagApiTemplate = await extractorExecutor.GenerateTagApiTemplateAsync(
+                It.IsAny<string>(),
+                It.IsAny<List<string>>(),
+                currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.TagApi)).Should().BeTrue();
+
+            tagApiTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
+            tagApiTemplate.TypedResources.Tags.Count().Should().Be(4);
+            tagApiTemplate.Resources.Count().Should().Be(4);
+
+            var resources = tagApiTemplate.TypedResources;
+
+            resources.Tags.Any(x => x.Name.Contains(MockTagClient.TagName1)).Should().BeTrue();
+            resources.Tags.Any(x => x.Name.Contains(MockTagClient.TagName2)).Should().BeTrue();
+            resources.Tags.All(x => x.ApiVersion == GlobalConstants.ApiVersion).Should().BeTrue();
+            resources.Tags.All(x => !x.DependsOn.IsNullOrEmpty() && !string.IsNullOrEmpty(x.DependsOn.First())).Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
- Fixed NRE occuring when running all-apis extraction (also renamed `ApiTag` to `TagApi` template to match naming with other extractors)
- Fixed InvalidOperation occuring for `api-version-set` extractor and `product-apis` extractor by replacing `SingleOrDefault` with `FirstOrDefault`
- Fixed unrefactored `LoggerExtractor` using null variable

Closes #652 