### PR TITLE
update api-version to 2021-08-01

### DIFF
--- a/src/ArmTemplates/Common/Constants/GlobalConstants.cs
+++ b/src/ArmTemplates/Common/Constants/GlobalConstants.cs
@@ -12,7 +12,7 @@
         public const string ExtractDescription = "Extract an existing API Management instance";
 
         public const string ApiVersion = "2021-08-01";
-        public const string LinkedAPIVersion = "2018-05-01";
+        public const string LinkedAPIVersion = "2021-08-01";
         public const int NumOfRecords = 100;
 
         public const string azAccessToken = "account get-access-token --query \"accessToken\" --output json";

--- a/src/ArmTemplates/Common/Constants/GlobalConstants.cs
+++ b/src/ArmTemplates/Common/Constants/GlobalConstants.cs
@@ -11,7 +11,7 @@
         public const string ExtractName = "extract";
         public const string ExtractDescription = "Extract an existing API Management instance";
 
-        public const string ApiVersion = "2021-01-01-preview";
+        public const string ApiVersion = "2021-08-01";
         public const string LinkedAPIVersion = "2018-05-01";
         public const int NumOfRecords = 100;
 

--- a/src/ArmTemplates/Properties/launchSettings.json
+++ b/src/ArmTemplates/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "apimtemplate": {
-      "commandName": "Project",
-      "commandLineArgs": "extract --extractorConfig C:\\Projects\\other\\2022-08-01-extractorConfig.json"
+      "commandName": "Project"
     }
   }
 }

--- a/src/ArmTemplates/Properties/launchSettings.json
+++ b/src/ArmTemplates/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "apimtemplate": {
       "commandName": "Project",
-      "commandLineArgs": "extract --extractorConfig C:\\Projects\\other\\extractorConfig.json"
+      "commandLineArgs": "extract --extractorConfig C:\\Projects\\other\\2022-08-01-extractorConfig.json"
     }
   }
 }


### PR DESCRIPTION
Updated apiVersion for all API calls to 2021-08-01 version.
Launched resource-kit general extraction (no specific parameters), below find a description with differences in output:

- No changes for policy-files found (.xml)
![image](https://user-images.githubusercontent.com/31598696/159970718-50c24599-016f-47dc-b12a-056210b83008.png)

- Template.jsons are different only in `apiVersion` fields (.json):
![image](https://user-images.githubusercontent.com/31598696/159971187-5a8012db-a5b9-4d23-9a3d-1c6f36ae3eeb.png)

I do not see any changes, so probably there is nothing I have to do. @adrianhall can you clarify, please?