### PR TITLE
Release Preparation

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -68,6 +68,7 @@ stages:
             inputs:
               command: publish
               arguments: '--configuration $(configuration) --output $(Build.ArtifactStagingDirectory)'
+              publishWebProjects: false
 
   - stage: postbuild
     displayName: 'Post Build Checks'

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -61,21 +61,14 @@ stages:
               command: 'test'
               arguments: '--configuration $(configuration) --collect "Code coverage"'
               publishTestResults: true
-              projects: 'tests/**/*.test.csproj'
+              projects: 'tests/**/*Tests/*.csproj'
 
-          - pwsh: |
-              Get-ChildItem -Path '$()' -Directory -Recurse | Where-Object { $_.FullName -match '\\bin|obj\\$(configuration)$' } | Write-Host
-            displayName: Show Build Directories
-
-          - pwsh: |
-              New-Item -Path '$(Build.Repository.LocalPath)\\src\\binaries\\$(configuration)' -ItemType Directory
-            displayName: Create binaries folder for Release Artifacts
-
-          - task: PublishBuildArtifacts@1
-            displayName: Publish Build Artifacts
+          - task: DotNetCoreCLI@2
             inputs:
-              pathToPublish: 'src/binaries/$(configuration)'
-              artifactName: build
+              command: publish
+              publishWebProjects: True
+              arguments: '--configuration $(configuration) --output $(Build.ArtifactStagingDirectory)'
+              zipAfterPublish: True
 
   - stage: postbuild
     displayName: 'Post Build Checks'

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -64,11 +64,10 @@ stages:
               projects: 'tests/**/*Tests/*.csproj'
 
           - task: DotNetCoreCLI@2
+            displayName: 'Publish build artifacts'
             inputs:
               command: publish
-              publishWebProjects: True
               arguments: '--configuration $(configuration) --output $(Build.ArtifactStagingDirectory)'
-              zipAfterPublish: True
 
   - stage: postbuild
     displayName: 'Post Build Checks'

--- a/src/ArmTemplates/ArmTemplates.csproj
+++ b/src/ArmTemplates/ArmTemplates.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="4.0.6-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Authorization" Version="2.9.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />

--- a/src/ArmTemplates/ArmTemplates.csproj
+++ b/src/ArmTemplates/ArmTemplates.csproj
@@ -24,17 +24,12 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="4.0.6-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.Authorization" Version="2.9.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="YamlDotNet" Version="5.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ArmTemplates/Extractor/EntityExtractors/GroupExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/GroupExtractor.cs
@@ -8,7 +8,6 @@ using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Bui
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Groups;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
-using Microsoft.Azure.Management.Authorization.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors

--- a/src/ArmTemplates/Program.cs
+++ b/src/ArmTemplates/Program.cs
@@ -46,8 +46,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates
                     await creatorCommandApplication.ExecuteCommandAsync(creatorConfig);
                 },
 
-                async errors =>
-                {
+                errors => {
                     applicationLogger.Information("Azure API Management DevOps Resource toolkit finished.");
 
                     if (!errors.IsNullOrEmpty())
@@ -63,8 +62,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates
                             {
                                 case ErrorType.VersionRequestedError:
                                 case ErrorType.HelpRequestedError:
-                                    return;
-
+                                    return Task.CompletedTask;
                                 case ErrorType.HelpVerbRequestedError:
                                     applicationLogger.Error("No verb found. Use \"help\" command to view all supported commands.");
                                     break;
@@ -84,10 +82,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates
                             var errorMessage = (i < errorMessages.Count) ? errorMessages[i] : string.Empty;
 
                             applicationLogger.Error("[{0}] {1}", errorList[i].Tag, errorMessage);
-                        }                        
+                        }
                     }
-                }
-            );
+
+                    return Task.CompletedTask;
+                });
         }
 
         public static IServiceProvider CreateServiceProvider(ILogger logger)

--- a/tests/ArmTemplates.Tests/ArmTemplates.Tests.csproj
+++ b/tests/ArmTemplates.Tests/ArmTemplates.Tests.csproj
@@ -16,18 +16,18 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+      <PackageReference Include="YamlDotNet" Version="11.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="YamlDotNet" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.5.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApiOperationClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApiOperationClient.cs
@@ -4,14 +4,11 @@
 //  </copyright>
 // --------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiOperations;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
-using Microsoft.Azure.Management.Compute.Fluent.Models;
 using Moq;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients


### PR DESCRIPTION
Preparing for release:
- updated all used NuGets to latest version
- removed all unused NuGets
- removed a `async method without await operations` warning
- fixed path for finding tests in pipeline (now tests are actually executed)
- fixed publishing artifacts using prebuild command [publish](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/dotnet-core?view=azure-devops&tabs=dotnetfive#publish-artifacts-to-azure-pipelines)