### PR TITLE
Add null checks on overriding config

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -103,14 +103,16 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         {
             var serviceDiagnostics = await this.diagnosticClient.GetAllAsync(extractorParameters);
 
-            var serviceloggerIds = new Dictionary<string, string>();
             foreach (var serviceDiagnostic in serviceDiagnostics)
             {
                 string loggerId = serviceDiagnostic.Properties.LoggerId;
-                
-                this.Cache.ServiceLevelDiagnosticLoggerBindings.Add(
-                    ParameterNamingHelper.GenerateValidParameterName(serviceDiagnostic.Name, ParameterPrefix.Diagnostic),
-                    loggerId);
+
+                var serviceDiagnosticsKey = ParameterNamingHelper.GenerateValidParameterName(serviceDiagnostic.Name, ParameterPrefix.Diagnostic);
+
+                if (!this.Cache.ServiceLevelDiagnosticLoggerBindings.ContainsKey(serviceDiagnosticsKey))
+                {
+                    this.Cache.ServiceLevelDiagnosticLoggerBindings.Add(serviceDiagnosticsKey, loggerId);
+                }
             }
 
             if (apisToExtract.IsNullOrEmpty())

--- a/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
+++ b/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
@@ -126,17 +126,17 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             // there can be no service url parameters in overriding configuration
             // this.ServiceUrlParameters = overridingConfig.ServiceUrlParameters ?? this.ServiceUrlParameters;
 
-            this.ParameterizeServiceUrl = overridingConfig.ParamServiceUrl != null && overridingConfig.ParamServiceUrl.Equals("true", StringComparison.OrdinalIgnoreCase) || overridingConfig.ServiceUrlParameters != null;
-            this.ParameterizeNamedValue = overridingConfig.ParamNamedValue != null && overridingConfig.ParamNamedValue.Equals("true", StringComparison.OrdinalIgnoreCase);
-            this.ParameterizeApiLoggerId = overridingConfig.ParamApiLoggerId != null && overridingConfig.ParamApiLoggerId.Equals("true", StringComparison.OrdinalIgnoreCase);
-            this.ParameterizeLogResourceId = overridingConfig.ParamLogResourceId != null && overridingConfig.ParamLogResourceId.Equals("true", StringComparison.OrdinalIgnoreCase);
-            this.NotIncludeNamedValue = overridingConfig.NotIncludeNamedValue != null && overridingConfig.NotIncludeNamedValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+            this.ParameterizeServiceUrl = !string.IsNullOrEmpty(overridingConfig.ParamServiceUrl) ? overridingConfig.ParamServiceUrl.Equals("true", StringComparison.OrdinalIgnoreCase) || overridingConfig.ServiceUrlParameters != null : this.ParameterizeServiceUrl;
+            this.ParameterizeNamedValue = !string.IsNullOrEmpty(overridingConfig.ParamNamedValue) ? overridingConfig.ParamNamedValue.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeNamedValue;
+            this.ParameterizeApiLoggerId = !string.IsNullOrEmpty(overridingConfig.ParamApiLoggerId) ? overridingConfig.ParamApiLoggerId.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeApiLoggerId;
+            this.ParameterizeLogResourceId = !string.IsNullOrEmpty(overridingConfig.ParamLogResourceId) ? overridingConfig.ParamLogResourceId.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeLogResourceId;
+            this.NotIncludeNamedValue = !string.IsNullOrEmpty(overridingConfig.NotIncludeNamedValue) ? overridingConfig.NotIncludeNamedValue.Equals("true", StringComparison.OrdinalIgnoreCase) : this.NotIncludeNamedValue;
             this.OperationBatchSize = overridingConfig.OperationBatchSize ?? this.OperationBatchSize;
-            this.ParamNamedValuesKeyVaultSecrets = overridingConfig.ParamNamedValuesKeyVaultSecrets != null && overridingConfig.ParamNamedValuesKeyVaultSecrets.Equals("true", StringComparison.OrdinalIgnoreCase);
-            this.ParameterizeBackend = overridingConfig.ParamBackend != null && overridingConfig.ParamBackend.Equals("true", StringComparison.OrdinalIgnoreCase);
-            this.SplitApis = !string.IsNullOrEmpty(overridingConfig.SplitAPIs) && overridingConfig.SplitAPIs.Equals("true", StringComparison.OrdinalIgnoreCase);
-            this.IncludeAllRevisions = !string.IsNullOrEmpty(overridingConfig.IncludeAllRevisions) && overridingConfig.IncludeAllRevisions.Equals("true", StringComparison.OrdinalIgnoreCase);
-            this.ExtractGateways = string.IsNullOrEmpty(overridingConfig.ExtractGateways) ? this.ExtractGateways : overridingConfig.ExtractGateways.Equals("true", StringComparison.OrdinalIgnoreCase);
+            this.ParamNamedValuesKeyVaultSecrets = !string.IsNullOrEmpty(overridingConfig.ParamNamedValuesKeyVaultSecrets) ? overridingConfig.ParamNamedValuesKeyVaultSecrets.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParamNamedValuesKeyVaultSecrets;
+            this.ParameterizeBackend = !string.IsNullOrEmpty(overridingConfig.ParamBackend) ? overridingConfig.ParamBackend.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeBackend;
+            this.SplitApis = !string.IsNullOrEmpty(overridingConfig.SplitAPIs) ? overridingConfig.SplitAPIs.Equals("true", StringComparison.OrdinalIgnoreCase) : this.SplitApis;
+            this.IncludeAllRevisions = !string.IsNullOrEmpty(overridingConfig.IncludeAllRevisions) ? overridingConfig.IncludeAllRevisions.Equals("true", StringComparison.OrdinalIgnoreCase) : this.IncludeAllRevisions;
+            this.ExtractGateways = !string.IsNullOrEmpty(overridingConfig.ExtractGateways) ? overridingConfig.ExtractGateways.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ExtractGateways;
 
             if (!string.IsNullOrEmpty(overridingConfig.BaseFileName) && !string.IsNullOrEmpty(overridingConfig.BaseFileName))
             {

--- a/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
+++ b/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             this.ExtractGateways = extractorConfig.ExtractGateways != null && extractorConfig.ExtractGateways.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
-        internal ExtractorParameters OverrideConfiguration(ExtractorConsoleAppConfiguration overridingConfig)
+        public ExtractorParameters OverrideConfiguration(ExtractorConsoleAppConfiguration overridingConfig)
         {
             if (overridingConfig == null) return this;
 
@@ -121,8 +121,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             this.PolicyXMLBaseUrl = overridingConfig.PolicyXMLBaseUrl ?? this.PolicyXMLBaseUrl;
             this.PolicyXMLSasToken = overridingConfig.PolicyXMLSasToken ?? this.PolicyXMLSasToken;
             this.ApiVersionSetName = overridingConfig.ApiVersionSetName ?? this.ApiVersionSetName;
-            this.IncludeAllRevisions = overridingConfig.IncludeAllRevisions != null && overridingConfig.IncludeAllRevisions.Equals("true", StringComparison.OrdinalIgnoreCase);
-            
+            this.OperationBatchSize = overridingConfig.OperationBatchSize ?? this.OperationBatchSize;
+
             // there can be no service url parameters in overriding configuration
             // this.ServiceUrlParameters = overridingConfig.ServiceUrlParameters ?? this.ServiceUrlParameters;
 
@@ -131,14 +131,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             this.ParameterizeApiLoggerId = !string.IsNullOrEmpty(overridingConfig.ParamApiLoggerId) ? overridingConfig.ParamApiLoggerId.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeApiLoggerId;
             this.ParameterizeLogResourceId = !string.IsNullOrEmpty(overridingConfig.ParamLogResourceId) ? overridingConfig.ParamLogResourceId.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeLogResourceId;
             this.NotIncludeNamedValue = !string.IsNullOrEmpty(overridingConfig.NotIncludeNamedValue) ? overridingConfig.NotIncludeNamedValue.Equals("true", StringComparison.OrdinalIgnoreCase) : this.NotIncludeNamedValue;
-            this.OperationBatchSize = overridingConfig.OperationBatchSize ?? this.OperationBatchSize;
             this.ParamNamedValuesKeyVaultSecrets = !string.IsNullOrEmpty(overridingConfig.ParamNamedValuesKeyVaultSecrets) ? overridingConfig.ParamNamedValuesKeyVaultSecrets.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParamNamedValuesKeyVaultSecrets;
             this.ParameterizeBackend = !string.IsNullOrEmpty(overridingConfig.ParamBackend) ? overridingConfig.ParamBackend.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeBackend;
             this.SplitApis = !string.IsNullOrEmpty(overridingConfig.SplitAPIs) ? overridingConfig.SplitAPIs.Equals("true", StringComparison.OrdinalIgnoreCase) : this.SplitApis;
             this.IncludeAllRevisions = !string.IsNullOrEmpty(overridingConfig.IncludeAllRevisions) ? overridingConfig.IncludeAllRevisions.Equals("true", StringComparison.OrdinalIgnoreCase) : this.IncludeAllRevisions;
             this.ExtractGateways = !string.IsNullOrEmpty(overridingConfig.ExtractGateways) ? overridingConfig.ExtractGateways.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ExtractGateways;
 
-            if (!string.IsNullOrEmpty(overridingConfig.BaseFileName) && !string.IsNullOrEmpty(overridingConfig.BaseFileName))
+            if (!string.IsNullOrEmpty(overridingConfig.BaseFileName))
             {
                 this.FileNames = this.GenerateFileNames(overridingConfig.BaseFileName, overridingConfig.SourceApimName);
             }

--- a/tests/ArmTemplates.Tests/Extractor/Configuration/ExtractorConfigurationOverrideTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Configuration/ExtractorConfigurationOverrideTests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configurations;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Configuration
+{
+    [Trait("Category", "Unit")]
+    public class ExtractorConfigurationOverrideTests : ExtractorMockerTestsBase
+    {
+        [Fact]
+        public void ExtractorConfigValidate_NoPropertiesSet_MissingParameterException()
+        {
+            var defaultExtractorConfig = new ExtractorConsoleAppConfiguration
+            {
+                IncludeAllRevisions = true.ToString(),
+                ParamApiLoggerId = true.ToString(),
+                ParamBackend = true.ToString(),
+                ParamLogResourceId = true.ToString(),
+                ParamNamedValue = true.ToString(),
+                ParamNamedValuesKeyVaultSecrets = true.ToString(),
+                ParamServiceUrl = true.ToString(),
+                NotIncludeNamedValue = true.ToString(),
+                SplitAPIs = true.ToString(),
+                ExtractGateways = true.ToString()
+            };
+
+            var extractorParameters = new ExtractorParameters(defaultExtractorConfig);
+            extractorParameters = extractorParameters.OverrideConfiguration(new ExtractorConsoleAppConfiguration());
+
+            extractorParameters.IncludeAllRevisions.Should().BeTrue();
+            extractorParameters.ParameterizeServiceUrl.Should().BeTrue();
+            extractorParameters.ParameterizeNamedValue.Should().BeTrue();
+            extractorParameters.ParameterizeApiLoggerId.Should().BeTrue();
+            extractorParameters.ParameterizeLogResourceId.Should().BeTrue();
+            extractorParameters.NotIncludeNamedValue.Should().BeTrue();
+            extractorParameters.ParamNamedValuesKeyVaultSecrets.Should().BeTrue();
+            extractorParameters.ParameterizeBackend.Should().BeTrue();
+            extractorParameters.SplitApis.Should().BeTrue();
+            extractorParameters.IncludeAllRevisions.Should().BeTrue();
+            extractorParameters.ExtractGateways.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
Every bool parameter specified in the extractor config file is overridden with false even if it is not specified in the command line because there is no null check in place. With this PR I check that every bool param has value before overriding it.