### PR TITLE
Allow backend.proxy parameterization

### DIFF
--- a/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
+++ b/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
@@ -90,6 +90,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configu
         [Option(longName: "paramBackend", HelpText = "Parameterize environment specific values from backend")]
         public string ParamBackend { get; set; }
 
+        [Option(longName: "paramBackendProxy", HelpText = "Parameterize backend proxy section")]
+        public string ParameterizeBackendProxySection { get; set; }
+
         [Option(longName: "extractGateways", HelpText = "Attempt to extract information about Self-Hosted gateways")]
         public string ExtractGateways { get; set; }
     }

--- a/src/ArmTemplates/Common/Constants/GlobalConstants.cs
+++ b/src/ArmTemplates/Common/Constants/GlobalConstants.cs
@@ -39,7 +39,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants
         public const string ApimServiceName = "apimServiceName";
         public const string LinkedTemplatesBaseUrl = "linkedTemplatesBaseUrl";
         public const string NamedValueKeyVaultSecrets = "namedValueKeyVaultSecrets";
+
+        #region Backend
+
         public const string BackendSettings = "backendSettings";
+        public const string BackendProxy = "backendProxy";
+
+        #endregion
     }
 
     public static class ParameterPrefix

--- a/src/ArmTemplates/Common/Templates/Abstractions/TemplateParameterProperties.Generic.cs
+++ b/src/ArmTemplates/Common/Templates/Abstractions/TemplateParameterProperties.Generic.cs
@@ -1,0 +1,17 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions
+{
+    public class TemplateParameterProperties<TParameter> : TemplateParameterProperties
+    {   
+        public new TParameter[] AllowedValues { get; set; }
+
+        [JsonProperty("defaultValue")]
+        public new TParameter Value { get; set; }
+    }
+}

--- a/src/ArmTemplates/Common/Templates/Abstractions/TemplateParameterProperties.cs
+++ b/src/ArmTemplates/Common/Templates/Abstractions/TemplateParameterProperties.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
         
         public string[] AllowedValues { get; set; }
 
-        public string DefaultValue { get; set; }
-
         public string Value { get; set; }
 
         public TemplateParameterProperties()

--- a/src/ArmTemplates/Common/Templates/Abstractions/TemplateParameterProperties.cs
+++ b/src/ArmTemplates/Common/Templates/Abstractions/TemplateParameterProperties.cs
@@ -8,9 +8,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
     public class TemplateParameterProperties
     {
         public string Type { get; set; }
+        
         public TemplateParameterMetadata Metadata { get; set; }
+        
         public string[] AllowedValues { get; set; }
+
         public string DefaultValue { get; set; }
+
         public string Value { get; set; }
 
         public TemplateParameterProperties()

--- a/src/ArmTemplates/Common/Templates/Backend/Parameters/BackendProxySectionParameter.cs
+++ b/src/ArmTemplates/Common/Templates/Backend/Parameters/BackendProxySectionParameter.cs
@@ -1,0 +1,16 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Backend.Parameters
+{
+    class BackendProxySectionParameter
+    {
+        public string Url { get; set; }
+
+        public string Username { get; set; }
+
+        public string Password { get; set; }
+    }
+}

--- a/src/ArmTemplates/Common/Templates/Builders/Abstractions/ITemplateBuilder.cs
+++ b/src/ArmTemplates/Common/Templates/Builders/Abstractions/ITemplateBuilder.cs
@@ -24,6 +24,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
         public Template<TTemplateResources> Build<TTemplateResources>()
             where TTemplateResources : ITemplateResources, new();
 
+        /// <summary>
+        /// Builds generic template using pre-defined template resources
+        /// </summary>
+        /// <typeparam name="TTemplateResources">type of resources of template, which has parameterless constructor</typeparam>
+        public Template<TTemplateResources> Build<TTemplateResources>(TTemplateResources templateResources)
+            where TTemplateResources : ITemplateResources, new();
+
         TemplateBuilder GenerateTemplateWithApimServiceNameProperty();
 
         TemplateBuilder GenerateTemplateWithPresetProperties(ExtractorParameters extractorParameters);
@@ -36,7 +43,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
 
         TemplateBuilder AddParameterizeApiLoggerIdProperty(ExtractorParameters extractorParameters);
 
-        TemplateBuilder AddParameterizeBackendProperty(ExtractorParameters extractorParameters);
+        TemplateBuilder AddParameterizeBackendSettings(ExtractorParameters extractorParameters);
 
         TemplateBuilder AddParameterizeLogResourceIdProperty(ExtractorParameters extractorParameters);
     }

--- a/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.Backend.cs
+++ b/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.Backend.cs
@@ -1,0 +1,52 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Backend.Parameters;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders
+{
+    public partial class TemplateBuilder : ITemplateBuilder
+    {
+        public TemplateBuilder AddParameterizeBackendSettings(ExtractorParameters extractorParameters)
+        {
+            if (extractorParameters.ParameterizeBackend)
+            {
+                TemplateParameterProperties extractBackendParametersProperties = new TemplateParameterProperties()
+                {
+                    Type = "object"
+                };
+                this.template.Parameters.Add(ParameterNames.BackendSettings, extractBackendParametersProperties);
+            }
+
+            return this;
+        }
+
+        public TemplateBuilder AddParameterizeBackendProxySection(ExtractorParameters extractorParameters)
+        {
+            if (extractorParameters.ParameterizeBackendProxySection)
+            {
+                var backendProxySectionParameterObject = new TemplateParameterProperties<BackendProxySectionParameter>
+                {
+                    Type = "object",
+                    Metadata = new() { Description = "proxy settings for backend resource (view https://docs.microsoft.com/en-us/rest/api/apimanagement/current-ga/backend/create-or-update)" },
+                    Value = new BackendProxySectionParameter
+                    {
+                        Url = "preset-proxy-url-value",
+                        Username = "preset-proxy-username-value",
+                        Password = "preset-proxy-password-value"
+                    }
+                };
+
+                this.template.Parameters.Add(ParameterNames.BackendProxy, backendProxySectionParameterObject);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.Loggers.cs
+++ b/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.Loggers.cs
@@ -1,0 +1,29 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders
+{
+    public partial class TemplateBuilder : ITemplateBuilder
+    {
+        public TemplateBuilder AddParameterizeLogResourceIdProperty(ExtractorParameters extractorParameters)
+        {
+            if (extractorParameters.ParameterizeLogResourceId)
+            {
+                TemplateParameterProperties loggerResourceIdParameterProperties = new TemplateParameterProperties()
+                {
+                    Type = "object"
+                };
+                this.template.Parameters.Add(ParameterNames.LoggerResourceId, loggerResourceIdParameterProperties);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.NamedValues.cs
+++ b/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.NamedValues.cs
@@ -1,0 +1,43 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders
+{
+    public partial class TemplateBuilder : ITemplateBuilder
+    {
+        public TemplateBuilder AddParameterizeNamedValueParameters(ExtractorParameters extractorParameters)
+        {
+            if (extractorParameters.ParameterizeNamedValue)
+            {
+                TemplateParameterProperties namedValueParameterProperties = new TemplateParameterProperties()
+                {
+                    Type = "object"
+                };
+                this.template.Parameters.Add(ParameterNames.NamedValues, namedValueParameterProperties);
+            }
+
+            return this;
+        }
+
+        public TemplateBuilder AddParameterizeNamedValuesKeyVaultSecretParameters(ExtractorParameters extractorParameters)
+        {
+            if (extractorParameters.ParamNamedValuesKeyVaultSecrets)
+            {
+                TemplateParameterProperties keyVaultNamedValueParameterProperties = new TemplateParameterProperties()
+                {
+                    Type = "object"
+                };
+                this.template.Parameters.Add(ParameterNames.NamedValueKeyVaultSecrets, keyVaultNamedValueParameterProperties);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.cs
+++ b/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.cs
@@ -11,7 +11,7 @@ using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders
 {
-    public class TemplateBuilder : ITemplateBuilder
+    public partial class TemplateBuilder : ITemplateBuilder
     {
         Template template;
 
@@ -22,6 +22,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
         public Template<TTemplateResources> Build<TTemplateResources>()
             where TTemplateResources : ITemplateResources, new()
         {
+            return this.Build<TTemplateResources>(new());
+        }
+
+        /// <inheritdoc/>
+        public Template<TTemplateResources> Build<TTemplateResources>(TTemplateResources templateResources)
+            where TTemplateResources : ITemplateResources, new()
+        {
             // left Template.NotGeneric variant for backward compatibility
             // for refactored code please use Template.Generic and use explicit TTemplateResources type
             var genericTemplate = new Template<TTemplateResources>();
@@ -30,7 +37,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
             genericTemplate.ContentVersion = this.template.ContentVersion;
             genericTemplate.Parameters = this.template.Parameters;
             genericTemplate.Variables = this.template.Variables;
-            genericTemplate.TypedResources = new TTemplateResources(); // creating empty resources
+            genericTemplate.TypedResources = templateResources;
             genericTemplate.Outputs = this.template.Outputs;
 
             return genericTemplate;
@@ -118,62 +125,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
                     Type = "object"
                 };
                 this.template.Parameters.Add(ParameterNames.ApiLoggerId, apiLoggerProperty);
-            }
-
-            return this;
-        }
-
-        public TemplateBuilder AddParameterizeNamedValueParameters(ExtractorParameters extractorParameters)
-        {
-            if (extractorParameters.ParameterizeNamedValue)
-            {
-                TemplateParameterProperties namedValueParameterProperties = new TemplateParameterProperties()
-                {
-                    Type = "object"
-                };
-                this.template.Parameters.Add(ParameterNames.NamedValues, namedValueParameterProperties);
-            }
-
-            return this;
-        }
-
-        public TemplateBuilder AddParameterizeNamedValuesKeyVaultSecretParameters(ExtractorParameters extractorParameters)
-        {
-            if (extractorParameters.ParamNamedValuesKeyVaultSecrets)
-            {
-                TemplateParameterProperties keyVaultNamedValueParameterProperties = new TemplateParameterProperties()
-                {
-                    Type = "object"
-                };
-                this.template.Parameters.Add(ParameterNames.NamedValueKeyVaultSecrets, keyVaultNamedValueParameterProperties);
-            }
-
-            return this;
-        }
-
-        public TemplateBuilder AddParameterizeLogResourceIdProperty(ExtractorParameters extractorParameters)
-        {
-            if (extractorParameters.ParameterizeLogResourceId)
-            {
-                TemplateParameterProperties loggerResourceIdParameterProperties = new TemplateParameterProperties()
-                {
-                    Type = "object"
-                };
-                this.template.Parameters.Add(ParameterNames.LoggerResourceId, loggerResourceIdParameterProperties);
-            }
-
-            return this;
-        }
-
-        public TemplateBuilder AddParameterizeBackendProperty(ExtractorParameters extractorParameters)
-        {
-            if (extractorParameters.ParameterizeBackend)
-            {
-                TemplateParameterProperties extractBackendParametersProperties = new TemplateParameterProperties()
-                {
-                    Type = "object"
-                };
-                this.template.Parameters.Add(ParameterNames.BackendSettings, extractBackendParametersProperties);
             }
 
             return this;

--- a/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         {
             var backendTemplate = this.templateBuilder
                                         .GenerateTemplateWithApimServiceNameProperty()
-                                        .AddParameterizeBackendProperty(extractorParameters)
+                                        .AddParameterizeBackendSettings(extractorParameters)
+                                        .AddParameterizeBackendProxySection(extractorParameters)
                                         .Build<BackendTemplateResources>();
 
             var backends = await this.backendClient.GetAllAsync(extractorParameters);
@@ -71,6 +72,17 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 backendResource.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{originalBackendName}')]";
                 backendResource.Type = ResourceTypeConstants.Backend;
                 backendResource.ApiVersion = GlobalConstants.ApiVersion;
+
+                // set backend proxy section values according to parameter
+                if (extractorParameters.ParameterizeBackendProxySection)
+                {
+                    backendResource.Properties.Proxy = new BackendProxy
+                    {
+                        Url = $"[parameters('{ParameterNames.BackendProxy}').url]",
+                        Username = $"[parameters('{ParameterNames.BackendProxy}').username]",
+                        Password = $"[parameters('{ParameterNames.BackendProxy}').password]"
+                    };
+                }
 
                 if (string.IsNullOrEmpty(singleApiName))
                 {

--- a/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
+++ b/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
@@ -79,6 +79,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
 
         public bool ParameterizeBackend { get; private set; }
 
+        public bool ParameterizeBackendProxySection { get; private set; }
+
         public bool ExtractGateways { get; set; }
 
         public ExtractorParameters(ExtractorConsoleAppConfiguration extractorConfig)
@@ -104,6 +106,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             this.OperationBatchSize = extractorConfig.OperationBatchSize ?? default;
             this.ParamNamedValuesKeyVaultSecrets = extractorConfig.ParamNamedValuesKeyVaultSecrets != null && extractorConfig.ParamNamedValuesKeyVaultSecrets.Equals("true", StringComparison.OrdinalIgnoreCase);
             this.ParameterizeBackend = extractorConfig.ParamBackend != null && extractorConfig.ParamBackend.Equals("true", StringComparison.OrdinalIgnoreCase);
+            this.ParameterizeBackendProxySection = extractorConfig.ParameterizeBackendProxySection != null && extractorConfig.ParameterizeBackendProxySection.Equals("true", StringComparison.OrdinalIgnoreCase);
             this.SplitApis = !string.IsNullOrEmpty(extractorConfig.SplitAPIs) && extractorConfig.SplitAPIs.Equals("true", StringComparison.OrdinalIgnoreCase);
             this.IncludeAllRevisions = !string.IsNullOrEmpty(extractorConfig.IncludeAllRevisions) && extractorConfig.IncludeAllRevisions.Equals("true", StringComparison.OrdinalIgnoreCase);
             this.FileNames = this.GenerateFileNames(extractorConfig.BaseFileName, extractorConfig.SourceApimName);
@@ -138,6 +141,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             this.NotIncludeNamedValue = !string.IsNullOrEmpty(overridingConfig.NotIncludeNamedValue) ? overridingConfig.NotIncludeNamedValue.Equals("true", StringComparison.OrdinalIgnoreCase) : this.NotIncludeNamedValue;
             this.ParamNamedValuesKeyVaultSecrets = !string.IsNullOrEmpty(overridingConfig.ParamNamedValuesKeyVaultSecrets) ? overridingConfig.ParamNamedValuesKeyVaultSecrets.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParamNamedValuesKeyVaultSecrets;
             this.ParameterizeBackend = !string.IsNullOrEmpty(overridingConfig.ParamBackend) ? overridingConfig.ParamBackend.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeBackend;
+            this.ParameterizeBackendProxySection = !string.IsNullOrEmpty(overridingConfig.ParameterizeBackendProxySection) ? overridingConfig.ParameterizeBackendProxySection.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParameterizeBackendProxySection;
             this.SplitApis = !string.IsNullOrEmpty(overridingConfig.SplitAPIs) ? overridingConfig.SplitAPIs.Equals("true", StringComparison.OrdinalIgnoreCase) : this.SplitApis;
             this.IncludeAllRevisions = !string.IsNullOrEmpty(overridingConfig.IncludeAllRevisions) ? overridingConfig.IncludeAllRevisions.Equals("true", StringComparison.OrdinalIgnoreCase) : this.IncludeAllRevisions;
             this.ExtractGateways = !string.IsNullOrEmpty(overridingConfig.ExtractGateways) ? overridingConfig.ExtractGateways.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ExtractGateways;

--- a/src/README.md
+++ b/src/README.md
@@ -416,7 +416,8 @@ You have two choices when specifying your settings:
 | serviceBaseUrl | No                    | Specify the base url where you want to run your extractor |
 | notIncludeNamedValue | No                    | Set to "true" will not generate Named Value Templates|
 | paramNamedValuesKeyVaultSecrets | No | Set to true will parameterize all named values where the value is from a key vault secret |
-| paramBackend | No | Set to true will parameterize sepcific backend values (limited to resourceId, url and protocol) |
+| paramBackend | No | Set to true will parameterize specific backend values (limited to resourceId, url and protocol) |
+| paramBackendProxy | No | Set to true will include `backendProxy` parameter in the output configuration file. Inner properties specification will set the same `proxy` settings to each backend resource |
 | extractGateways | No | Set to true will attempt to extract the Self Hosted Gateways. |
 
 #### Note

--- a/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
         protected const bool MockNotIncludeNamedValue = true;
         protected const bool MockToParameterizeNamedValuesKeyVaultSecrets = true;
         protected const int MockOperationBatchSize = 32;
-        protected const bool MockParameterizeBackend = true;
+        protected const bool MockParameterizeBackendSettings = true;
+        protected const bool MockParameterizeBackendProxySection = false;
         protected const bool MockExtractGateways = true;
 
         protected ExtractorConsoleAppConfiguration GetMockedExtractorConsoleAppConfiguration(
@@ -43,7 +44,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             string multipleApiNames = MockMultipleApis,
             bool includeAllRevisions = MockIncludeAllRevisions,
             bool toParameterizeApiLoggerId = MockParameterizeApiLoggerId,
-            bool toNotIncludeNamedValue = MockNotIncludeNamedValue)
+            bool toNotIncludeNamedValue = MockNotIncludeNamedValue,
+            bool parameterizeBackendProxySection = MockParameterizeBackendProxySection)
         {
             return new ExtractorConsoleAppConfiguration
             {
@@ -71,7 +73,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 NotIncludeNamedValue = toNotIncludeNamedValue.ToString(),
                 ParamNamedValuesKeyVaultSecrets = MockToParameterizeNamedValuesKeyVaultSecrets.ToString(),
                 OperationBatchSize = MockOperationBatchSize,
-                ParamBackend = MockParameterizeBackend.ToString(),
+                ParamBackend = MockParameterizeBackendSettings.ToString(),
+                ParameterizeBackendProxySection = parameterizeBackendProxySection.ToString(),
                 ExtractGateways = MockExtractGateways.ToString()
             };
         }  

--- a/tests/ArmTemplates.Tests/Extractor/Configuration/ExtractorParametersCreationTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Configuration/ExtractorParametersCreationTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             extractorParameters.NotIncludeNamedValue.Should().Be(MockNotIncludeNamedValue);
             extractorParameters.ParamNamedValuesKeyVaultSecrets.Should().Be(MockToParameterizeNamedValuesKeyVaultSecrets);
             extractorParameters.OperationBatchSize.Should().Be(MockOperationBatchSize);
-            extractorParameters.ParameterizeBackend.Should().Be(MockParameterizeBackend);
+            extractorParameters.ParameterizeBackend.Should().Be(MockParameterizeBackendSettings);
 
             // more complicated assertions with parsing arguments
             extractorParameters.MultipleApiNames.Should().Contain(new[] { "test-multiple-api-1", "test-multiple-api-2" });

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/BackendExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/BackendExtractorTests.cs
@@ -84,5 +84,61 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             backendProperties.Url.Should().Contain(ParameterNames.BackendSettings);
             backendProperties.Protocol.Should().Contain(ParameterNames.BackendSettings);
         }
+
+        [Fact]
+        public async Task ParameterizeBackendProxySection_SetsProxyToParameterDefault()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(ParameterizeBackendProxySection_SetsProxyToParameterDefault));
+
+            var extractorConfig = this.GetMockedExtractorConsoleAppConfiguration(
+                splitApis: false,
+                apiVersionSetName: string.Empty,
+                multipleApiNames: string.Empty,
+                includeAllRevisions: false,
+                // proxy section has to be parameterized
+                parameterizeBackendProxySection: true);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var mockPolicyExtractor = new Mock<IPolicyExtractor>(MockBehavior.Strict);
+            mockPolicyExtractor
+                .Setup(x => x.GetCachedPolicyContent(It.IsAny<PolicyTemplateResource>(), It.IsAny<string>()))
+                .Returns((PolicyTemplateResource policy, string _) => $"mock-response-from-policy-{policy.Name}");
+
+            var mockBackendClient = MockBackendClient.GetMockedApiClientWithDefaultValues();
+            var backendExtractor = new BackendExtractor(
+                this.GetTestLogger<BackendExtractor>(),
+                new TemplateBuilder(),
+                mockPolicyExtractor.Object,
+                mockBackendClient);
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                backendExtractor: backendExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            // act
+            var backendTemplate = await extractorExecutor.GenerateBackendTemplateAsync(
+                singleApiName: null,
+                new List<PolicyTemplateResource>(),
+                new List<NamedValueTemplateResource>(),
+                currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Backends)).Should().BeTrue();
+
+            backendTemplate.Parameters.Should().ContainKey(ParameterNames.BackendProxy);
+
+            backendTemplate.TypedResources.Backends.Should().HaveCount(1);
+            backendTemplate.Resources.Should().HaveCount(1);
+            backendTemplate.TypedResources.Backends.First().Type.Should().Be(ResourceTypeConstants.Backend);
+            backendTemplate.TypedResources.Backends.First().Name.Should().Contain(MockBackendClient.BackendName);
+
+            // proxySection has to be dependant on file-global backend-proxy-parameter
+            var proxySection = backendTemplate.TypedResources.Backends.First().Properties.Proxy;
+            proxySection.Url.Should().Contain(ParameterNames.BackendProxy);
+            proxySection.Username.Should().Contain(ParameterNames.BackendProxy);
+            proxySection.Password.Should().Contain(ParameterNames.BackendProxy);
+        }
     }
 }

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockBackendClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockBackendClient.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                         Properties = new BackendTemplateProperties
                         {
                             Description = $"{BackendName}-description",
-                            Credentials = new(),
-                            Tls = new(),
                             Url = $"{BackendName}-url",
                             Protocol = $"{BackendName}-protocol",
                             Proxy = new() 


### PR DESCRIPTION
Added new console flag `--paramBackendProxy`. Flag set to true includes such a complex-object parameter in the output template file and sets the same settings to all of backend resources extracted.

![image](https://user-images.githubusercontent.com/31598696/166254105-d85e558c-4140-42f1-97a9-a3b2b9c103a9.png)

Closes #622 