### PR TITLE
Align PolicyXMLBaseUrl/PolicyXMLSasToken behaviour across extractors

### DIFF
--- a/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.cs
+++ b/src/ArmTemplates/Common/Templates/Builders/TemplateBuilder.cs
@@ -80,16 +80,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
 
         public TemplateBuilder AddPolicyProperties(ExtractorParameters extractorParameters)
         {
-            if (extractorParameters.PolicyXMLBaseUrl != null && extractorParameters.PolicyXMLSasToken != null)
-            {
-                TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
-                {
-                    Type = "string"
-                };
-
-                this.template.Parameters.Add(ParameterNames.PolicyXMLSasToken, policyTemplateSasTokenParameterProperties);
-            }
-
             if (extractorParameters.PolicyXMLBaseUrl != null)
             {
                 TemplateParameterProperties policyTemplateBaseUrlParameterProperties = new TemplateParameterProperties()
@@ -97,8 +87,18 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
                     Type = "string"
                 };
                 this.template.Parameters.Add(ParameterNames.PolicyXMLBaseUrl, policyTemplateBaseUrlParameterProperties);
-            }
 
+
+                if (extractorParameters.PolicyXMLSasToken != null)
+                {
+                    TemplateParameterProperties policyTemplateSasTokenParameterProperties = new TemplateParameterProperties()
+                    {
+                        Type = "string"
+                    };
+
+                    this.template.Parameters.Add(ParameterNames.PolicyXMLSasToken, policyTemplateSasTokenParameterProperties);
+                }
+            }
             return this;
         }
 

--- a/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -287,11 +287,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         {
             MasterTemplateResource masterResourceTemplate = CreateLinkedMasterTemplateResource(name, uriLink, dependsOn);
 
-            if (extractorParameters.PolicyXMLBaseUrl != null)
+            if (extractorParameters.PolicyXMLBaseUrl is not null)
             {
                 masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLBaseUrl, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLBaseUrl}')]" });
 
-                if (extractorParameters.PolicyXMLSasToken != null)
+                if (extractorParameters.PolicyXMLSasToken is not null)
                 {
                     masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLSasToken, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLSasToken}')]" });
                 }

--- a/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -127,14 +127,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 
                 var productDeployment = CreateLinkedMasterTemplateResource(ProductsTemplate, productsUri, dependsOnNamedValues);
                 
-                if (!string.IsNullOrEmpty(extractorParameters.PolicyXMLBaseUrl))
+                if (extractorParameters.PolicyXMLBaseUrl is not null)
                 {
                     productDeployment.Properties.Parameters.Add(ParameterNames.PolicyXMLBaseUrl, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLBaseUrl}')]" });
-                }
 
-                if (!string.IsNullOrEmpty(extractorParameters.PolicyXMLSasToken))
-                {
-                    productDeployment.Properties.Parameters.Add(ParameterNames.PolicyXMLSasToken, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLSasToken}')]" });
+                    if (extractorParameters.PolicyXMLSasToken is not null)
+                    {
+                        productDeployment.Properties.Parameters.Add(ParameterNames.PolicyXMLSasToken, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLSasToken}')]" });
+                    }
                 }
 
                 masterResources.DeploymentResources.Add(productDeployment);
@@ -251,11 +251,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             if (extractorParameters.PolicyXMLBaseUrl != null)
             {
                 masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLBaseUrl, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLBaseUrl}')]" });
+                
+                if (extractorParameters.PolicyXMLSasToken != null)
+                {
+                    masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLSasToken, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLSasToken}')]" });
+                }
             }
-            if (extractorParameters.PolicyXMLSasToken != null)
-            {
-                masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLSasToken, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLSasToken}')]" });
-            }
+            
             if (extractorParameters.ParameterizeServiceUrl)
             {
                 masterResourceTemplate.Properties.Parameters.Add(ParameterNames.ServiceUrl, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.ServiceUrl}')]" });
@@ -288,11 +290,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             if (extractorParameters.PolicyXMLBaseUrl != null)
             {
                 masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLBaseUrl, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLBaseUrl}')]" });
+
+                if (extractorParameters.PolicyXMLSasToken != null)
+                {
+                    masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLSasToken, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLSasToken}')]" });
+                }
             }
-            if (extractorParameters.PolicyXMLSasToken != null)
-            {
-                masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLSasToken, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLSasToken}')]" });
-            }
+            
             return masterResourceTemplate;
         }
 
@@ -363,13 +367,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                     new TemplateParameterProperties(metadataDescription: "Query string for the URL of the repository", type: "string"));
             }
 
-            if (!string.IsNullOrEmpty(extractorParameters.PolicyXMLBaseUrl))
+            if (extractorParameters.PolicyXMLBaseUrl is not null)
             {
                 parameters.Add(
                     ParameterNames.PolicyXMLBaseUrl,
                     new TemplateParameterProperties(metadataDescription: "Base URL of the repository that contains the generated policy files", type: "string"));
 
-                if (!string.IsNullOrEmpty(extractorParameters.PolicyXMLSasToken))
+                if (extractorParameters.PolicyXMLSasToken is not null)
                 {
                     parameters.Add(
                         ParameterNames.PolicyXMLSasToken,

--- a/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/MasterTemplateExtractor.cs
@@ -248,11 +248,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         static MasterTemplateResource CreateLinkedMasterTemplateResourceForApiTemplate(string name, string uriLink, string[] dependsOn, ExtractorParameters extractorParameters)
         {
             MasterTemplateResource masterResourceTemplate = CreateLinkedMasterTemplateResource(name, uriLink, dependsOn);
-            if (extractorParameters.PolicyXMLBaseUrl != null)
+            if (extractorParameters.PolicyXMLBaseUrl is not null)
             {
                 masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLBaseUrl, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLBaseUrl}')]" });
                 
-                if (extractorParameters.PolicyXMLSasToken != null)
+                if (extractorParameters.PolicyXMLSasToken is not null)
                 {
                     masterResourceTemplate.Properties.Parameters.Add(ParameterNames.PolicyXMLSasToken, new TemplateParameterProperties() { Value = $"[parameters('{ParameterNames.PolicyXMLSasToken}')]" });
                 }

--- a/src/ArmTemplates/Extractor/EntityExtractors/ParametersExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ParametersExtractor.cs
@@ -77,14 +77,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 
             void AddPolicyParameters()
             {
-                if (string.IsNullOrEmpty(extractorParameters.PolicyXMLBaseUrl))
+                if (extractorParameters.PolicyXMLBaseUrl is null)
                 {
                     return;
                 }
 
                 parameters.Add(ParameterNames.PolicyXMLBaseUrl, new() { Value = extractorParameters.PolicyXMLBaseUrl });
 
-                if (!string.IsNullOrEmpty(extractorParameters.PolicyXMLSasToken))
+                if (extractorParameters.PolicyXMLSasToken is not null)
                 {
                     parameters.Add(ParameterNames.PolicyXMLSasToken, new() { Value = extractorParameters.PolicyXMLSasToken });
                 }

--- a/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             };
         }
 
-        protected ExtractorParameters CreateDefaultExtractorParameters(
+        protected ExtractorConsoleAppConfiguration GetDefaultExtractorConsoleAppConfiguration(
                string sourceApimName = MockSourceApimName,
                string destinationApimName = MockDestinationApimName,
                string resourceGroup = MockResourceGroup,
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
          )
         {
 
-            var extractorConfiguration = new ExtractorConsoleAppConfiguration
+            return new ExtractorConsoleAppConfiguration
             {
                 SourceApimName = sourceApimName,
                 DestinationApimName = destinationApimName,
@@ -138,8 +138,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 ParamBackend = paramBackend,
                 ExtractGateways = extractGateways
             };
-
-            return new ExtractorParameters(extractorConfiguration);
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
@@ -43,8 +43,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             string multipleApiNames = MockMultipleApis,
             bool includeAllRevisions = MockIncludeAllRevisions,
             bool toParameterizeApiLoggerId = MockParameterizeApiLoggerId,
-            bool toNotIncludeNamedValue = MockNotIncludeNamedValue)
+            bool toNotIncludeNamedValue = MockNotIncludeNamedValue,
+            string policyXmlBaseUrl = MockPolicyXMLBaseUrl,
+            string policyXmlSasToken = MockPolicyXMLSasToken)
         {
+
             return new ExtractorConsoleAppConfiguration
             {
                 SourceApimName = MockSourceApimName,
@@ -56,8 +59,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 LinkedTemplatesBaseUrl = MockLinkedTemplatesBaseUrl,
                 LinkedTemplatesSasToken = MockLinkedTemplatesSasToken,
                 LinkedTemplatesUrlQueryString = MockLinkedTemplatesUrlQueryString,
-                PolicyXMLBaseUrl = MockPolicyXMLBaseUrl,
-                PolicyXMLSasToken = MockPolicyXMLSasToken,
+                PolicyXMLBaseUrl = policyXmlBaseUrl,
+                PolicyXMLSasToken = policyXmlSasToken,
                 SplitAPIs = splitApis.ToString(),
                 ApiVersionSetName = apiVersionSetName,
                 IncludeAllRevisions = includeAllRevisions.ToString(),

--- a/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
 {
     public abstract class ExtractorMockerTestsBase : TestsBase
     {
-        protected const string MockSourceApimName = "dmkorolev-APIM-test";
-        protected const string MockDestinationApimName = "test-destination-apim-name";
-        protected const string MockResourceGroup = "dmkorolev-test";
+        protected const string MockSourceApimName = "source-apim-name";
+        protected const string MockDestinationApimName = "destination-apim-name";
+        protected const string MockResourceGroup = "resource-group";
         protected const string MockFileFolder = "test-file-folder";
         protected const string MockApiName = "echo-api";
         protected const string MockMultipleApis = " test-multiple-api-1, test-multiple-api-2 ";
@@ -77,6 +77,69 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 ParamBackend = MockParameterizeBackendSettings.ToString(),
                 ExtractGateways = MockExtractGateways.ToString()
             };
-        }  
+        }
+
+        protected ExtractorParameters CreateDefaultExtractorParameters(
+               string sourceApimName = MockSourceApimName,
+               string destinationApimName = MockDestinationApimName,
+               string resourceGroup = MockResourceGroup,
+               string fileFolder = MockFileFolder,
+               string apiName = MockApiName,
+               string multipleAPIs = null,
+               string linkedTemplatesBaseUrl = null,
+               string linkedTemplatesSasToken = null,
+               string linkedTemplatesUrlQueryString = null,
+               string policyXmlBaseUrl = null,
+               string policyXmlSasToken = null,
+               string splitAPIs = null,
+               string apiVersionSetName = null,
+               string includeAllRevisions = null,
+               string baseFileName = null,
+               ServiceUrlProperty[] serviceUrlParameters = null,
+               string paramServiceUrl = null,
+               string paramNamedValue = null,
+               string paramApiLoggerId = null,
+               string paramLogResourceId = null,
+               string serviceBaseUrl = null,
+               string notIncludeNamedValue = null,
+               string paramNamedValuesKeyVaultSecrets = null,
+               int? operationBatchSize = null,
+               string paramBackend = null,
+               string extractGateways = null
+         )
+        {
+
+            var extractorConfiguration = new ExtractorConsoleAppConfiguration
+            {
+                SourceApimName = sourceApimName,
+                DestinationApimName = destinationApimName,
+                ResourceGroup = resourceGroup,
+                FileFolder = fileFolder,
+                ApiName = apiName,
+                MultipleAPIs = multipleAPIs,
+                LinkedTemplatesBaseUrl = linkedTemplatesBaseUrl,
+                LinkedTemplatesSasToken = linkedTemplatesSasToken,
+                LinkedTemplatesUrlQueryString = linkedTemplatesUrlQueryString,
+                PolicyXMLBaseUrl = policyXmlBaseUrl,
+                PolicyXMLSasToken = policyXmlSasToken,
+                SplitAPIs = splitAPIs,
+                ApiVersionSetName = apiVersionSetName,
+                IncludeAllRevisions = includeAllRevisions,
+                BaseFileName = baseFileName,
+                ServiceUrlParameters = serviceUrlParameters,
+                ParamServiceUrl = paramServiceUrl,
+                ParamNamedValue = paramNamedValue,
+                ParamApiLoggerId = paramApiLoggerId,
+                ParamLogResourceId = paramLogResourceId,
+                ServiceBaseUrl = serviceBaseUrl,
+                NotIncludeNamedValue = notIncludeNamedValue,
+                ParamNamedValuesKeyVaultSecrets = paramNamedValuesKeyVaultSecrets,
+                OperationBatchSize = operationBatchSize,
+                ParamBackend = paramBackend,
+                ExtractGateways = extractGateways
+            };
+
+            return new ExtractorParameters(extractorConfiguration);
+        }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/MasterTemplateExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/MasterTemplateExtractorTests.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 splitApis: false,
                 apiVersionSetName: string.Empty,
                 multipleApiNames: string.Empty,
-                includeAllRevisions: false);
+                includeAllRevisions: false,
+                policyXmlBaseUrl: string.Empty,
+                policyXmlSasToken: string.Empty);
             var extractorParameters = new ExtractorParameters(extractorConfig);
 
             var masterTemplateExtractor = new MasterTemplateExtractor(

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/MasterTemplateExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/MasterTemplateExtractorTests.cs
@@ -100,6 +100,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             masterTemplate.Parameters.Should().ContainKey(ParameterNames.LoggerResourceId);
             masterTemplate.Parameters.Should().ContainKey(ParameterNames.NamedValueKeyVaultSecrets);
             masterTemplate.Parameters.Should().ContainKey(ParameterNames.BackendSettings);
+            masterTemplate.Parameters.Should().ContainKey(ParameterNames.PolicyXMLBaseUrl);
+            masterTemplate.Parameters.Should().ContainKey(ParameterNames.PolicyXMLBaseUrl);
 
             masterTemplate.TypedResources.DeploymentResources.Should().HaveCount(2);
             masterTemplate.Resources.Should().HaveCount(2);

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ParametersExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ParametersExtractorTests.cs
@@ -49,21 +49,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             // arrange
             var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateParametersTemplates_ProperlyLaysTheInformation));
 
-            var extractorConfig = this.GetMockedExtractorConsoleAppConfiguration(
-                splitApis: false,
-                apiVersionSetName: string.Empty,
-                multipleApiNames: string.Empty,
-                includeAllRevisions: false);
-            
-            extractorConfig.ParamNamedValue = "false";
-            extractorConfig.ParamNamedValuesKeyVaultSecrets = "false";
-            extractorConfig.ParamServiceUrl = "false";
-            extractorConfig.ServiceUrlParameters = null;
-            extractorConfig.ParamApiLoggerId = null;
-            extractorConfig.ParamLogResourceId = null;
-            extractorConfig.ParamBackend = null;
+            var extractorParameters = this.CreateDefaultExtractorParameters(
+                policyXmlBaseUrl: string.Empty,
+                policyXmlSasToken: string.Empty
+            );
 
-            var extractorParameters = new ExtractorParameters(extractorConfig);
             var extractorExecutor = this.GetExtractorInstance(extractorParameters);
 
             // act
@@ -72,9 +62,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Parameters)).Should().BeTrue();
 
             parametersTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
-            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesBaseUrl);
-            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesSasToken);
-            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesUrlQueryString);
             parametersTemplate.Parameters.Should().ContainKey(ParameterNames.PolicyXMLBaseUrl);
             parametersTemplate.Parameters.Should().ContainKey(ParameterNames.PolicyXMLSasToken);
 
@@ -86,23 +73,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             // arrange
             var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateParametersTemplates_ProperlyLaysTheInformation_PolicyExcluded));
 
-            var extractorConfig = this.GetMockedExtractorConsoleAppConfiguration(
-                splitApis: false,
-                apiVersionSetName: string.Empty,
-                multipleApiNames: string.Empty,
-                includeAllRevisions: false,
+            var extractorParameters = this.CreateDefaultExtractorParameters(
                 policyXmlBaseUrl: null,
-                policyXmlSasToken: null);
+                policyXmlSasToken: null
+            );
 
-            extractorConfig.ParamNamedValue = "false";
-            extractorConfig.ParamNamedValuesKeyVaultSecrets = "false";
-            extractorConfig.ParamServiceUrl = "false";
-            extractorConfig.ServiceUrlParameters = null;
-            extractorConfig.ParamApiLoggerId = null;
-            extractorConfig.ParamLogResourceId = null;
-            extractorConfig.ParamBackend = null;
-
-            var extractorParameters = new ExtractorParameters(extractorConfig);
             var extractorExecutor = this.GetExtractorInstance(extractorParameters);
             
             // act
@@ -111,9 +86,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Parameters)).Should().BeTrue();
 
             parametersTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
-            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesBaseUrl);
-            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesSasToken);
-            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesUrlQueryString);
             parametersTemplate.Parameters.Should().NotContainKey(ParameterNames.PolicyXMLBaseUrl);
             parametersTemplate.Parameters.Should().NotContainKey(ParameterNames.PolicyXMLSasToken);
         }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ParametersExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ParametersExtractorTests.cs
@@ -49,10 +49,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             // arrange
             var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateParametersTemplates_ProperlyLaysTheInformation));
 
-            var extractorParameters = this.CreateDefaultExtractorParameters(
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
                 policyXmlBaseUrl: string.Empty,
                 policyXmlSasToken: string.Empty
             );
+            var extractorParameters = new ExtractorParameters(extractorConfig);
 
             var extractorExecutor = this.GetExtractorInstance(extractorParameters);
 
@@ -73,10 +74,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             // arrange
             var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateParametersTemplates_ProperlyLaysTheInformation_PolicyExcluded));
 
-            var extractorParameters = this.CreateDefaultExtractorParameters(
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
                 policyXmlBaseUrl: null,
                 policyXmlSasToken: null
             );
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
 
             var extractorExecutor = this.GetExtractorInstance(extractorParameters);
             

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ParametersExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ParametersExtractorTests.cs
@@ -1,0 +1,121 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Scenarios
+{
+    [Trait("Category", "Parameters Extraction")]
+    public class ParametersExtractorTests : ExtractorMockerWithOutputTestsBase
+    {
+        public ParametersExtractorTests() : base("parameters-tests")
+        {
+        }
+
+        ExtractorExecutor GetExtractorInstance(ExtractorParameters extractorParameters) 
+        {
+            var parametersExtractor = new ParametersExtractor(new TemplateBuilder(), null);
+
+            var loggerExtractor = new LoggerExtractor(
+                this.GetTestLogger<LoggerExtractor>(),
+                new TemplateBuilder(),
+                null,
+                null);
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                parametersExtractor: parametersExtractor,
+                loggerExtractor: loggerExtractor);
+
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            return extractorExecutor;
+        }
+
+        [Fact]
+        public async Task GenerateParametersTemplates_ProperlyLaysTheInformation()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateParametersTemplates_ProperlyLaysTheInformation));
+
+            var extractorConfig = this.GetMockedExtractorConsoleAppConfiguration(
+                splitApis: false,
+                apiVersionSetName: string.Empty,
+                multipleApiNames: string.Empty,
+                includeAllRevisions: false);
+            
+            extractorConfig.ParamNamedValue = "false";
+            extractorConfig.ParamNamedValuesKeyVaultSecrets = "false";
+            extractorConfig.ParamServiceUrl = "false";
+            extractorConfig.ServiceUrlParameters = null;
+            extractorConfig.ParamApiLoggerId = null;
+            extractorConfig.ParamLogResourceId = null;
+            extractorConfig.ParamBackend = null;
+
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+            var extractorExecutor = this.GetExtractorInstance(extractorParameters);
+
+            // act
+            var parametersTemplate = await extractorExecutor.GenerateParametersTemplateAsync(null, null, null, null, currentTestDirectory);
+
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Parameters)).Should().BeTrue();
+
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesBaseUrl);
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesSasToken);
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesUrlQueryString);
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.PolicyXMLBaseUrl);
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.PolicyXMLSasToken);
+
+        }
+
+        [Fact]
+        public async Task GenerateParametersTemplates_ProperlyLaysTheInformation_PolicyExcluded()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateParametersTemplates_ProperlyLaysTheInformation_PolicyExcluded));
+
+            var extractorConfig = this.GetMockedExtractorConsoleAppConfiguration(
+                splitApis: false,
+                apiVersionSetName: string.Empty,
+                multipleApiNames: string.Empty,
+                includeAllRevisions: false,
+                policyXmlBaseUrl: null,
+                policyXmlSasToken: null);
+
+            extractorConfig.ParamNamedValue = "false";
+            extractorConfig.ParamNamedValuesKeyVaultSecrets = "false";
+            extractorConfig.ParamServiceUrl = "false";
+            extractorConfig.ServiceUrlParameters = null;
+            extractorConfig.ParamApiLoggerId = null;
+            extractorConfig.ParamLogResourceId = null;
+            extractorConfig.ParamBackend = null;
+
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+            var extractorExecutor = this.GetExtractorInstance(extractorParameters);
+            
+            // act
+            var parametersTemplate = await extractorExecutor.GenerateParametersTemplateAsync(null, null, null, null, currentTestDirectory);
+
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Parameters)).Should().BeTrue();
+
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesBaseUrl);
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesSasToken);
+            parametersTemplate.Parameters.Should().ContainKey(ParameterNames.LinkedTemplatesUrlQueryString);
+            parametersTemplate.Parameters.Should().NotContainKey(ParameterNames.PolicyXMLBaseUrl);
+            parametersTemplate.Parameters.Should().NotContainKey(ParameterNames.PolicyXMLSasToken);
+        }
+    }
+}


### PR DESCRIPTION
PolicyXMLBaseUrl and PolicyXMLSasToken parameters generation behaviour aligned across extractors.

- If  PolicyXMLBaseUrl is not provided in config at all, this parameter will not be included into the output parameter and policies will be included as rawxml in the templates (**was implemented before**)
- If policyXMLBaseUrl and policyXMLSasToken both provided (including empty string) those parameters will be included into the output template
- Do not include policyXMLSasToken into parameters if policyXMLBaseUrl is not provided (meaning equal to null)

Resolves #351