### PR TITLE
Add parameterExampleContract definition for API request/response Models

### DIFF
--- a/src/ArmTemplates/Common/Templates/ApiOperations/ParameterExampleContract.cs
+++ b/src/ArmTemplates/Common/Templates/ApiOperations/ParameterExampleContract.cs
@@ -2,20 +2,17 @@
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //  Licensed under the MIT License.
 // --------------------------------------------------------------------------
-using System.Collections.Generic;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiOperations
 {
-    public class ApiOperationRepresentation
+    public class ParameterExampleContract
     {
-        public string ContentType { get; set; }
+        public string Description { get; set; }
 
-        public string SchemaId { get; set; }
+        public string ExternalValue { get; set; }
 
-        public string TypeName { get; set; }
+        public string Summary { get; set; }
 
-        public string Sample { get; set; }
-
-        public IDictionary<string, ParameterExampleContract> Examples { get; set; }
+        public object Value { get; set; }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorTests.cs
@@ -125,6 +125,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             apiTemplate.TypedResources.ApiOperations.All(x => x.Properties is not null).Should().BeTrue();
             apiTemplate.TypedResources.ApiOperations.SelectMany(x => x.DependsOn).Any(x => x.Contains($"'{ResourceTypeConstants.API}'")).Should().BeTrue();
             apiTemplate.TypedResources.ApiOperations.SelectMany(x => x.DependsOn).Any(x => x.Contains($"'{ResourceTypeConstants.APIOperation}'")).Should().BeFalse();
+            apiTemplate.TypedResources.ApiOperations.All(x => x.Properties.Request.Representations.Count() == 1).Should().BeTrue();
+            apiTemplate.TypedResources.ApiOperations.All(x => x.Properties.Responses.Count() == 1).Should().BeTrue();
+            apiTemplate.TypedResources.ApiOperations.All(x => x.Properties.Request.Representations.All(o => o.Examples.Count > 0)).Should().BeTrue();
+            apiTemplate.TypedResources.ApiOperations.All(x => x.Properties.Request.Representations.All(o => o.Examples.ContainsKey("default"))).Should().BeTrue();
 
             // api operations policies
             apiTemplate.TypedResources.ApiOperationsPolicies.Count().Should().Be(2);

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApiOperationClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApiOperationClient.cs
@@ -46,7 +46,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                 {
                     ContentType = "application/json",
                     SchemaId = "api-operation-representation-schema-id",
-                    TypeName = "api-operation-representation-type-name"
+                    TypeName = "api-operation-representation-type-name",
+                    Examples = new Dictionary<string, ParameterExampleContract>() {
+                        {"default", new ParameterExampleContract { Description = "description", Value = new object(), Summary = "summary" } }
+                    }
                 }
             }
         };
@@ -70,7 +73,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                 {
                     ContentType = "application/json",
                     SchemaId = "api-operation-representation-schema-id",
-                    TypeName = "api-operation-representation-type-name"
+                    TypeName = "api-operation-representation-type-name",
+                    Examples = new Dictionary<string, ParameterExampleContract>() {
+                        {"default", new ParameterExampleContract { Description = "description", Value = "plain value", Summary = "summary" } },
+                        {"not default", new ParameterExampleContract { Description = "description", Value = new object(), Summary = "summary" } }
+                    }
                 }
             }
         };

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisClient.cs
@@ -85,12 +85,21 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                 });
 
             mockServiceApiProductsApiClient
-                .Setup(x => x.GetSingleAsync(It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
+                .Setup(x => x.GetSingleAsync(It.Is<string>((o => o.Equals(ServiceApiName1))), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync(new ApiTemplateResource
                 {
                     Name = ServiceApiName1,
                     Type = TemplateType,
                     Properties = ServiceApiProperties1
+                });
+
+            mockServiceApiProductsApiClient
+                .Setup(x => x.GetSingleAsync(It.Is<string>((o => o.Equals(ServiceApiName2))), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new ApiTemplateResource
+                {
+                    Name = ServiceApiName2,
+                    Type = TemplateType,
+                    Properties = ServiceApiProperties2
                 });
 
 


### PR DESCRIPTION
**Update**
In the PR definition of model is refers to documentation:
https://docs.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-operation/get#parameterexamplecontract
https://docs.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-operation/create-or-update#parameterexamplecontract

**Original description:**
Model ParameterExampleContract was added in order to save the representation values.
Schema definition:  https://github.com/Azure/azure-resource-manager-schemas/blob/main/schemas/2021-08-01/Microsoft.ApiManagement.json

Closes #570 