### PR TITLE
Remove sample property from ApiOperationRepresentation

### DIFF
--- a/src/ArmTemplates/Common/Templates/ApiOperations/ApiOperationRepresentation.cs
+++ b/src/ArmTemplates/Common/Templates/ApiOperations/ApiOperationRepresentation.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
 
         public string TypeName { get; set; }
 
-        public string Sample { get; set; }
-
         public IDictionary<string, ParameterExampleContract> Examples { get; set; }
     }
 }


### PR DESCRIPTION
Sample property removed since it is not currently existing in current -ga version documentation for creation and get operation the **api operations** however it was in previous API. 

Please see the documentation: 

**Current api (2021-08-01)**
https://docs.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-operation/get#representationcontract
https://docs.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-operation/create-or-update#representationcontract

**Previous (2020-12-01)**
https://docs.microsoft.com/en-us/rest/api/apimanagement/previous-ga/api-operation/create-or-update#representationcontract
https://docs.microsoft.com/en-us/rest/api/apimanagement/previous-ga/api-operation/get#representationcontract

Sample property was replaced with Examples (Dictionary). 

Closes #707 