### PR TITLE
Handle duplicate key error in LoggerExtractor

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             return loggerTemplate;
         }
 
-        public async Task LoadAllReferencedLoggers(
+        async Task LoadAllReferencedLoggers(
             List<string> apisToExtract, 
             ExtractorParameters extractorParameters)
         {

--- a/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             return loggerTemplate;
         }
 
-        async Task LoadAllReferencedLoggers(
+        public async Task LoadAllReferencedLoggers(
             List<string> apisToExtract, 
             ExtractorParameters extractorParameters)
         {
@@ -148,9 +148,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 
                 if (!diagnosticLoggerBindings.IsNullOrEmpty())
                 {
-                    this.Cache.ApiDiagnosticLoggerBindings.Add(
-                        NamingHelper.GenerateValidParameterName(curApiName, ParameterPrefix.Api), 
-                        diagnosticLoggerBindings);
+                    var diagnosticLoggerKey = NamingHelper.GenerateValidParameterName(curApiName, ParameterPrefix.Api);
+                    if (!this.Cache.ApiDiagnosticLoggerBindings.ContainsKey(diagnosticLoggerKey))
+                    {
+                        this.Cache.ApiDiagnosticLoggerBindings.Add(diagnosticLoggerKey, diagnosticLoggerBindings);
+                    }
                 }
             }
         }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/LoggerExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/LoggerExtractorTests.cs
@@ -10,7 +10,9 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executors;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Logger.Cache;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Policy;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
@@ -69,6 +71,64 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
 
             loggerTemplate.TypedResources.Loggers.First().Name.Should().Contain(MockLoggerClient.LoggerName);
             loggerTemplate.TypedResources.Loggers.First().Properties.LoggerType.Should().Be(MockDiagnosticClient.DefaultDiagnosticName);
+        }
+
+        [Fact]
+        public async Task LoadAllReferencedLoggers_ShouldPopulateCacheWithoutError_GivenItCalledMultipleTimes()
+        {
+            // arrange
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
+                splitAPIs: "true",
+                paramApiLoggerId: "true",
+                apiName: string.Empty);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var mockedDiagnosticClient = MockDiagnosticClient.GetMockedApiClientWithDefaultValues();
+            var loggerExtractor = new LoggerExtractor(
+                this.GetTestLogger<LoggerExtractor>(),
+                new TemplateBuilder(),
+                default,
+                mockedDiagnosticClient);
+
+            var apisToTest = new List<string>() {
+                "echo-api",
+                "echo-api-2"
+            };
+
+            var diagnosticLoggerBinding = new DiagnosticLoggerBinding
+            {
+                DiagnosticName = NamingHelper.GenerateValidParameterName(MockDiagnosticClient.DefaultDiagnosticName, ParameterPrefix.Diagnostic),
+                LoggerId = MockDiagnosticClient.LoggerIdValue
+            };
+
+            var expectedApiDiagnosticLoggerBingingsValues = new Dictionary<string, ISet<DiagnosticLoggerBinding>>()
+            {
+                { 
+                    NamingHelper.GenerateValidParameterName("echo-api", ParameterPrefix.Api), 
+                    new HashSet<DiagnosticLoggerBinding>() { diagnosticLoggerBinding }  
+                },
+                { 
+                    NamingHelper.GenerateValidParameterName("echo-api-2", ParameterPrefix.Api),
+                    new HashSet<DiagnosticLoggerBinding>() { diagnosticLoggerBinding } 
+                }
+            };
+
+            // act
+            await loggerExtractor.LoadAllReferencedLoggers(apisToTest, extractorParameters);
+            foreach(var api in apisToTest)
+            {
+                await loggerExtractor.LoadAllReferencedLoggers(new List<string>() { api }, extractorParameters);
+            }
+
+            // assert
+            loggerExtractor.Cache.ServiceLevelDiagnosticLoggerBindings.Count.Should().Be(1);
+            loggerExtractor.Cache.ApiDiagnosticLoggerBindings.Count.Should().Be(2);
+            
+            foreach( var (key, value) in expectedApiDiagnosticLoggerBingingsValues)
+            {
+                loggerExtractor.Cache.ApiDiagnosticLoggerBindings[key].Count.Should().Be(1);
+                loggerExtractor.Cache.ApiDiagnosticLoggerBindings[key].First().Equals(value.First()).Should().BeTrue();
+            }
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockDiagnosticClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockDiagnosticClient.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
     {
         public const string DiagnosticName = "diagnostic";
         public const string DefaultDiagnosticName = "default-diagnostic";
+        public const string LoggerIdValue = "logger-id";
 
         public static IDiagnosticClient GetMockedClientWithApiDependentValues()
         {
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                         Name = DiagnosticName,
                         Properties = new DiagnosticTemplateProperties()
                         {
-                            LoggerId = "logger-id"
+                            LoggerId = LoggerIdValue
                         }
                     }
                 });
@@ -43,7 +44,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                         Name = $"{apiName}-{DiagnosticName}",
                         Properties = new DiagnosticTemplateProperties()
                         {
-                            LoggerId = "logger-id"
+                            LoggerId = LoggerIdValue
                         }
                     }
                 });
@@ -64,7 +65,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                         Name = DefaultDiagnosticName,
                         Properties = new DiagnosticTemplateProperties()
                         {
-                            LoggerId = "logger-id"
+                            LoggerId = LoggerIdValue
                         }
                     }
                 });
@@ -78,7 +79,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                         Name = DefaultDiagnosticName,
                         Properties = new DiagnosticTemplateProperties()
                         {
-                            LoggerId = "logger-id"
+                            LoggerId = LoggerIdValue
                         }
                     }
                 });


### PR DESCRIPTION
Closes #727 
PR addresses the bug with covering this method by test.
