### PR TITLE
Remove unused parameters from product template

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             ExtractorParameters extractorParameters)
         {
             var productsTemplate = this.templateBuilder
-                                        .GenerateTemplateWithPresetProperties(extractorParameters)
+                                        .GenerateTemplateWithApimServiceNameProperty()
+                                        .AddPolicyProperties(extractorParameters)
                                         .Build<ProductTemplateResources>();
 
             var products = await this.productsClient.GetAllAsync(extractorParameters);

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ProductsExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ProductsExtractorTests.cs
@@ -81,8 +81,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             templateParameters.Should().ContainKey(ParameterNames.ApimServiceName);
             templateParameters.Should().ContainKey(ParameterNames.PolicyXMLBaseUrl);
             templateParameters.Should().ContainKey(ParameterNames.PolicyXMLSasToken);
-            templateParameters.Should().ContainKey(ParameterNames.ServiceUrl);
-            templateParameters.Should().ContainKey(ParameterNames.ApiLoggerId);
 
             var templateResources = productTemplate.Resources;
 


### PR DESCRIPTION
Remove unused parameters form the generated product template. 
ServiceUrl, apiLoggerId
Closes #733 
