### PR TITLE
Remove dependsOn property from apiTags template

### DIFF
--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/TagApiExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/TagApiExtractorTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             resources.Tags.Any(x => x.Name.Contains(MockTagClient.TagName1)).Should().BeTrue();
             resources.Tags.Any(x => x.Name.Contains(MockTagClient.TagName2)).Should().BeTrue();
             resources.Tags.All(x => x.ApiVersion == GlobalConstants.ApiVersion).Should().BeTrue();
-            resources.Tags.All(x => !x.DependsOn.IsNullOrEmpty() && !string.IsNullOrEmpty(x.DependsOn.First())).Should().BeTrue();
+            resources.Tags.All(x => x.DependsOn.IsNullOrEmpty()).Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
Remove depends on property from the resources completely in apiTags template.
Currently in main branch it refers to previous created tag, which increases time of deployment. 
For information: In main linked template, apiTags is depends on tags and api template.