### PR TITLE
(#761) Removed ContractResolver from JsonSerializerSettings

### DIFF
--- a/src/ArmTemplates/Creator/Utilities/OpenApi.cs
+++ b/src/ArmTemplates/Creator/Utilities/OpenApi.cs
@@ -62,7 +62,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Creator.Utilitie
             {
                 // include StringEscaping to ensure single quotes are escaped
                 return JsonConvert.SerializeObject(this.definition_, settings: new JsonSerializerSettings { 
-                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
                     StringEscapeHandling = StringEscapeHandling.EscapeHtml 
                 });
             }


### PR DESCRIPTION
This pull request closes #761 

Removed `CamelCasePropertyNamesContractResolver` from `JsonSerializerSettings`
The format of the properties in the exported serialized openApi specification will not be changed to
camelCase.