### PR TITLE
Generate tagTemplate for singleApi provided with operation tags

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/TagExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/TagExtractor.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 // or if it is found in tags associated with the api
                 // or if it is found in tags associated with the products associated with the api
                 if (string.IsNullOrEmpty(singleApiName)
-                        || apiOperationTagResources.Any(t => t.Name.Contains($"/{tag}'"))
+                        || apiOperationTagResources.Any(t => t.Name.Contains($"/{tagOriginalName}'"))
                         || productAPIResources.Any(t => t.Name.Contains($"/{singleApiName}"))
                             && productTagResources.Any(t => t.Name.Contains($"/{tagOriginalName}'")))
                 {

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/TagExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/TagExtractorTests.cs
@@ -1,0 +1,133 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Castle.Core.Internal;
+using FluentAssertions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Products;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Tags;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients;
+using Xunit;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Scenarios
+{
+    [Trait("Category", "Tag Extraction")]
+    public class TagExtractorTests : ExtractorMockerWithOutputTestsBase
+    {
+        public TagExtractorTests() : base("tag-tests")
+        {
+        }
+
+        [Fact]
+        public async Task GenerateTagTemplates_GetAll_ProperlyLaysTheInformation()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateTagTemplates_GetAll_ProperlyLaysTheInformation));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration();
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var mockedTagClient = MockTagClient.GetMockedApiClientWithDefaultValues();
+            var tagExtractor = new TagExtractor(
+                this.GetTestLogger<TagExtractor>(),
+                mockedTagClient,
+                new TemplateBuilder());
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                tagExtractor: tagExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            ApiTemplateResources apiTemplateResources = new ApiTemplateResources();
+            ProductTemplateResources productTemplateResources = new ProductTemplateResources();
+
+            var tagTemplate = await extractorExecutor.GenerateTagTemplateAsync(
+                string.Empty,
+                apiTemplateResources,
+                productTemplateResources,
+                currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Tags)).Should().BeTrue();
+
+            tagTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
+            tagTemplate.TypedResources.Tags.Count().Should().Be(4);
+            tagTemplate.Resources.Count().Should().Be(4);
+
+            var resources = tagTemplate.TypedResources;
+
+            resources.Tags.Any(x => x.Name.Contains(MockTagClient.TagName1)).Should().BeTrue();
+            resources.Tags.Any(x => x.Name.Contains(MockTagClient.TagName2)).Should().BeTrue();
+            resources.Tags.Any(x => x.Name.Contains(MockTagClient.OperationTagName1)).Should().BeTrue();
+            resources.Tags.Any(x => x.Name.Contains(MockTagClient.OperationTagName2)).Should().BeTrue();
+            resources.Tags.All(x => x.DependsOn.IsNullOrEmpty()).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GenerateTagTemplates_GetApiOperationRelated_ProperlyLaysTheInformation()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateTagTemplates_GetApiOperationRelated_ProperlyLaysTheInformation));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration();
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var mockedTagClient = MockTagClient.GetMockedApiClientWithDefaultValues();
+            var tagExtractor = new TagExtractor(
+                this.GetTestLogger<TagExtractor>(),
+                mockedTagClient,
+                new TemplateBuilder());
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                tagExtractor: tagExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            ApiTemplateResources apiTemplateResources = new ApiTemplateResources()
+            {
+                ApiOperationsTags = new List<TagTemplateResource>()
+                {
+                    new TagTemplateResource()
+                    {
+                        Name = $"parameters'/{MockTagClient.OperationTagName1}'"
+                    },
+                    new TagTemplateResource()
+                    {
+                        Name = $"parameters/{MockTagClient.OperationTagName2}'"
+                    }
+                }
+            };
+            ProductTemplateResources productTemplateResources = new ProductTemplateResources();
+
+            var tagTemplate = await extractorExecutor.GenerateTagTemplateAsync(
+                "apiName1",
+                apiTemplateResources,
+                productTemplateResources,
+                currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Tags)).Should().BeTrue();
+
+            tagTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
+            tagTemplate.TypedResources.Tags.Count().Should().Be(2);
+            tagTemplate.Resources.Count().Should().Be(2);
+
+            var resources = tagTemplate.TypedResources;
+
+            resources.Tags.Any(x => x.Name.Contains(MockTagClient.OperationTagName1)).Should().BeTrue();
+            resources.Tags.Any(x => x.Name.Contains(MockTagClient.OperationTagName2)).Should().BeTrue();
+        }
+    }
+}

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockTagClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockTagClient.cs
@@ -16,12 +16,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
     {
         public const string TagName1 = "tag-1";
         public const string TagName2 = "tag-2";
+        public const string OperationTagName1 = "operation-tag-1";
+        public const string OperationTagName2 = "operation-tag-2";
 
         public static ITagClient GetMockedApiClientWithDefaultValues()
         {
-            var mockGroupsClient = new Mock<ITagClient>(MockBehavior.Strict);
+            var mockTagsClient = new Mock<ITagClient>(MockBehavior.Strict);
 
-            mockGroupsClient
+            mockTagsClient
                 .Setup(x => x.GetTagsLinkedToApiOperationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync(new List<TagTemplateResource>
                 {
@@ -38,7 +40,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                     }
                 });
 
-            mockGroupsClient
+            mockTagsClient
                 .Setup(x => x.GetAllTagsLinkedToApiAsync(It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync(new List<TagTemplateResource>
                 {
@@ -55,24 +57,51 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                     }
                 });
 
-            mockGroupsClient
+            mockTagsClient
                 .Setup(x => x.GetAllTagsLinkedToProductAsync(It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync(new List<TagTemplateResource>
                 {
                     new TagTemplateResource
                     {
                         Name = TagName1,
-                        Type = ResourceTypeConstants.ProductTag
+                        Type = ResourceTypeConstants.APITag
                     },
 
                     new TagTemplateResource
                     {
                         Name = TagName2,
-                        Type = ResourceTypeConstants.ProductTag
+                        Type = ResourceTypeConstants.APITag
                     }
                 });
 
-            return mockGroupsClient.Object;
+            mockTagsClient
+                .Setup(x => x.GetAllAsync(It.IsAny<ExtractorParameters>(), It.IsAny<int>()))
+                .ReturnsAsync(new List<TagTemplateResource>
+                {
+                    new TagTemplateResource
+                    {
+                        Name = TagName1,
+                        Type = ResourceTypeConstants.APITag
+                    },
+
+                    new TagTemplateResource
+                    {
+                        Name = TagName2,
+                        Type = ResourceTypeConstants.APITag
+                    },
+                    new TagTemplateResource
+                    {
+                        Name = OperationTagName1,
+                        Type = ResourceTypeConstants.APITag
+                    },
+                    new TagTemplateResource
+                    {
+                        Name = OperationTagName2,
+                        Type = ResourceTypeConstants.APITag
+                    }
+                });
+
+            return mockTagsClient.Object;
         }
     }
 }


### PR DESCRIPTION
TagExtractor in case of singleApi name is provided, compared the ApiOperationTags with incorrect value, resulting not finding and generating the tagTemplate file. 
Add TagsExtractor Tests. 
Closes #711 