### PR TITLE
Remove overriding document's value property

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/ApiSchemaExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ApiSchemaExtractor.cs
@@ -6,7 +6,6 @@
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
-using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiSchemas;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
@@ -36,7 +35,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             {
                 var apiSchemaOriginalName = apiSchema.Name;
 
-                apiSchema.Properties.Document.Value = this.GetSchemaValueBasedOnContentType(apiSchema.Properties);
                 apiSchema.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{apiSchemaOriginalName}')]";
                 apiSchema.Type = ResourceTypeConstants.APISchema;
                 apiSchema.ApiVersion = GlobalConstants.ApiVersion;
@@ -46,36 +44,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             }
 
             return apiSchemaResources;
-        }
-
-        string GetSchemaValueBasedOnContentType(ApiSchemaProperties schemaTemplateProperties)
-        {
-            if (schemaTemplateProperties is null)
-            {
-                return string.Empty;
-            }
-
-            var contentType = schemaTemplateProperties.ContentType.ToLowerInvariant();
-            if (contentType.Equals("application/vnd.oai.openapi.components+json"))
-            {
-                // for OpenAPI "value" is not used, but "components" which is resolved during json deserialization
-                return null;
-            }
-
-            var schemaValue = contentType switch
-            {
-                "application/vnd.ms-azure-apim.swagger.definitions+json" => schemaTemplateProperties?.Document?.Definitions?.Serialize(),
-                "application/vnd.ms-azure-apim.xsd+xml" => schemaTemplateProperties?.Document?.Definitions?.Serialize(),
-                "application/vnd.ms-azure-apim.graphql.schema" => schemaTemplateProperties?.Document?.Value?.ToString(),
-                _ => string.Empty
-            };
-
-            if (string.IsNullOrEmpty(schemaValue) && schemaTemplateProperties.Document is not null)
-            {
-                return schemaTemplateProperties.Document.Serialize();
-            }
-
-            return schemaValue;
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiSchemaExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiSchemaExtractorTests.cs
@@ -1,0 +1,57 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients;
+using Xunit;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Scenarios
+{
+    [Trait("Category", "Api Schema Extraction")]
+    public class ApiSchemaExtractorTests : ExtractorMockerWithOutputTestsBase
+    {
+        public ApiSchemaExtractorTests() : base("api-schema-tests")
+        {
+        }
+
+        [Fact]
+        public async Task GenerateApiTemplates_ProperlyParsesTheInformation()
+        {
+            // arrange
+            var responseFileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagementListApiSchemas_success_response.json");
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration();
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var mockedApiSchemaClient = await MockApiSchemaClient.GetMockedHttpApiSchemaClient(responseFileLocation);
+            var mockedApiSchemaExtractor = new ApiSchemaExtractor(this.GetTestLogger<ApiSchemaExtractor>(), mockedApiSchemaClient);
+
+            // act
+            var apiSchemas = await mockedApiSchemaExtractor.GenerateApiSchemaResourcesAsync("apiName", extractorParameters);
+
+            // assert
+            apiSchemas.ApiSchemas.Count().Should().Be(2);
+            apiSchemas.ApiSchemas.All(x => x.Type == ResourceTypeConstants.APISchema).Should().BeTrue();
+            apiSchemas.ApiSchemas.All(x => x.Properties is not null).Should().BeTrue();
+
+            var jsonSchema = apiSchemas.ApiSchemas.First(x=>x.Name.Contains("schemaName1"));
+            jsonSchema.Should().NotBeNull();
+            jsonSchema.Properties.Document.Value.Should().BeNull();
+
+            var xmlSchema = apiSchemas.ApiSchemas.First(x => x.Name.Contains("schemaName2"));
+            xmlSchema.Should().NotBeNull();
+            xmlSchema.Properties.Document.Value.Should().NotBeNull();
+            xmlSchema.Properties.Document.Definitions.Should().BeNull();
+            xmlSchema.Properties.Document.Components.Should().BeNull();
+        }
+    }
+}

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApiSchemaClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApiSchemaClient.cs
@@ -7,10 +7,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.ApiSchemas;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandlers;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiSchemas;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilities;
 using Moq;
+using Moq.Protected;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients
 {
@@ -75,6 +78,15 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                 });
 
             return mockApiSchemaClient.Object;
+        }
+
+        public static async Task<IApiSchemaClient> GetMockedHttpApiSchemaClient(string responseFileLocation)
+        {
+            var mockedClient= new Mock<ApiSchemaClient>(MockBehavior.Strict, await MockClientUtils.GenerateMockedIHttpClientFactoryWithResponse(responseFileLocation));
+            mockedClient.Protected()
+                .Setup<AzureCliAuthenticator>("Auth").Returns(MockClientUtils.GetMockedAzureClient());
+
+            return mockedClient.Object;
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagementListApiSchemas_success_response.json
+++ b/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagementListApiSchemas_success_response.json
@@ -1,0 +1,97 @@
+{
+  "value": [
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.ApiManagement/service/service-name/apis/apiId/schemas/schemaId1",
+      "type": "Microsoft.ApiManagement/service/apis/schemas",
+      "name": "schemaName1",
+      "properties": {
+        "contentType": "application/vnd.ms-azure-apim.swagger.definitions+json",
+        "document": {
+          "definitions": {
+            "Pet": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/NewPet"
+                },
+                {
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "format": "int64"
+                    }
+                  }
+                }
+              ]
+            },
+            "NewPet": {
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            },
+            "Error": {
+              "type": "object",
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            },
+            "Tags": {
+              "items": {
+                "type": "string"
+              },
+              "x-apim-inline": true
+            },
+            "Limit": {
+              "format": "int32",
+              "x-apim-inline": true
+            },
+            "PetArray": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            },
+            "Id": {
+              "format": "int64",
+              "x-apim-inline": true
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.ApiManagement/service/service-name/apis/apiId/schemas/schemaId2",
+      "type": "Microsoft.ApiManagement/service/apis/schemas",
+      "name": "schemaName2",
+      "properties": {
+        "contentType": "application/vnd.ms-azure-apim.xsd+xml",
+        "document": {
+          "value": "<s:schema elementFormDefault=\"qualified\" targetNamespace=\"http://ws.cdyne.com/WeatherWS/\" xmlns:tns=\"http://ws.cdyne.com/WeatherWS/\" xmlns:s=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://schemas.xmlsoap.org/wsdl/soap12/\" xmlns:mime=\"http://schemas.xmlsoap.org/wsdl/mime/\" xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\" xmlns:tm=\"http://microsoft.com/wsdl/mime/textMatching/\" xmlns:http=\"http://schemas.xmlsoap.org/wsdl/http/\" xmlns:soapenc=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\" xmlns:apim-wsdltns=\"http://ws.cdyne.com/WeatherWS/\">\r\n  <s:element name=\"GetWeatherInformation\">\r\n    <s:complexType />\r\n  </s:element>\r\n  <s:element name=\"GetWeatherInformationResponse\">\r\n    <s:complexType>\r\n      <s:sequence>\r\n        <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"GetWeatherInformationResult\" type=\"tns:ArrayOfWeatherDescription\" />\r\n      </s:sequence>\r\n    </s:complexType>\r\n  </s:element>\r\n  <s:complexType name=\"ArrayOfWeatherDescription\">\r\n    <s:sequence>\r\n      <s:element minOccurs=\"0\" maxOccurs=\"unbounded\" name=\"WeatherDescription\" type=\"tns:WeatherDescription\" />\r\n    </s:sequence>\r\n  </s:complexType>\r\n  <s:complexType name=\"WeatherDescription\">\r\n    <s:sequence>\r\n      <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"WeatherID\" type=\"s:short\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Description\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"PictureURL\" type=\"s:string\" />\r\n    </s:sequence>\r\n  </s:complexType>\r\n  <s:element name=\"GetCityForecastByZIP\">\r\n    <s:complexType>\r\n      <s:sequence>\r\n        <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"ZIP\" type=\"s:string\" />\r\n      </s:sequence>\r\n    </s:complexType>\r\n  </s:element>\r\n  <s:element name=\"GetCityForecastByZIPResponse\">\r\n    <s:complexType>\r\n      <s:sequence>\r\n        <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"GetCityForecastByZIPResult\" type=\"tns:ForecastReturn\" />\r\n      </s:sequence>\r\n    </s:complexType>\r\n  </s:element>\r\n  <s:complexType name=\"ForecastReturn\">\r\n    <s:sequence>\r\n      <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"Success\" type=\"s:boolean\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"ResponseText\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"State\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"City\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"WeatherStationCity\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"ForecastResult\" type=\"tns:ArrayOfForecast\" />\r\n    </s:sequence>\r\n  </s:complexType>\r\n  <s:complexType name=\"ArrayOfForecast\">\r\n    <s:sequence>\r\n      <s:element minOccurs=\"0\" maxOccurs=\"unbounded\" name=\"Forecast\" nillable=\"true\" type=\"tns:Forecast\" />\r\n    </s:sequence>\r\n  </s:complexType>\r\n  <s:complexType name=\"Forecast\">\r\n    <s:sequence>\r\n      <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"Date\" type=\"s:dateTime\" />\r\n      <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"WeatherID\" type=\"s:short\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Desciption\" type=\"s:string\" />\r\n      <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"Temperatures\" type=\"tns:temp\" />\r\n      <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"ProbabilityOfPrecipiation\" type=\"tns:POP\" />\r\n    </s:sequence>\r\n  </s:complexType>\r\n  <s:complexType name=\"temp\">\r\n    <s:sequence>\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"MorningLow\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"DaytimeHigh\" type=\"s:string\" />\r\n    </s:sequence>\r\n  </s:complexType>\r\n  <s:complexType name=\"POP\">\r\n    <s:sequence>\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Nighttime\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Daytime\" type=\"s:string\" />\r\n    </s:sequence>\r\n  </s:complexType>\r\n  <s:element name=\"GetCityWeatherByZIP\">\r\n    <s:complexType>\r\n      <s:sequence>\r\n        <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"ZIP\" type=\"s:string\" />\r\n      </s:sequence>\r\n    </s:complexType>\r\n  </s:element>\r\n  <s:element name=\"GetCityWeatherByZIPResponse\">\r\n    <s:complexType>\r\n      <s:sequence>\r\n        <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"GetCityWeatherByZIPResult\" type=\"tns:WeatherReturn\" />\r\n      </s:sequence>\r\n    </s:complexType>\r\n  </s:element>\r\n  <s:complexType name=\"WeatherReturn\">\r\n    <s:sequence>\r\n      <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"Success\" type=\"s:boolean\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"ResponseText\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"State\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"City\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"WeatherStationCity\" type=\"s:string\" />\r\n      <s:element minOccurs=\"1\" maxOccurs=\"1\" name=\"WeatherID\" type=\"s:short\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Description\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Temperature\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"RelativeHumidity\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Wind\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Pressure\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Visibility\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"WindChill\" type=\"s:string\" />\r\n      <s:element minOccurs=\"0\" maxOccurs=\"1\" name=\"Remarks\" type=\"s:string\" />\r\n    </s:sequence>\r\n  </s:complexType>\r\n  <s:element name=\"ArrayOfWeatherDescription\" nillable=\"true\" type=\"tns:ArrayOfWeatherDescription\" />\r\n  <s:element name=\"ForecastReturn\" nillable=\"true\" type=\"tns:ForecastReturn\" />\r\n  <s:element name=\"WeatherReturn\" type=\"tns:WeatherReturn\" />\r\n</s:schema>"
+        }
+      }
+    }
+  ],
+  "count": 2
+}


### PR DESCRIPTION
Previously the document's value was overridden, but there is no need in that, since we receive from API exactly what needs to be deployed without changing.
Closes #756, #738
Resolves #769 (Api schemas were supported already, there were no need in new implementation)
