### PR TITLE
Add loggerResourceId to logger template

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/LoggerExtractor.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         {
             var loggerTemplate = this.templateBuilder
                                         .GenerateTemplateWithApimServiceNameProperty()
+                                        .AddParameterizedLogResourceIdProperty(extractorParameters)
                                         .Build<LoggerTemplateResources>();
 
             if (extractorParameters.ParameterizeApiLoggerId)


### PR DESCRIPTION
Include loggerResourceId into the template file in case paramLogResourceId is "true"
Add basic test for paramLogResourceId parameter.

Closes #726 
