### PR TITLE
Restructure the API template generation, ordering revisions depends on property

### DIFF
--- a/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
@@ -1011,17 +1011,17 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             this.logger.LogInformation("Extracting singleAPI {0} with revisions", this.extractorParameters.SingleApiName);
 
             string currentRevision = null;
-            bool generateApiReleaseTemplate;
+            bool generateSingleApiReleaseTemplate;
             List<string> revList = new List<string>();
 
             await foreach (var apiRevision in this.apiRevisionExtractor.GetApiRevisionsAsync(this.extractorParameters.SingleApiName, this.extractorParameters))
             {
-                generateApiReleaseTemplate = false;
+                generateSingleApiReleaseTemplate = false;
                 var apiRevisionName = apiRevision.ApiId.Split("/")[2];
                 if (apiRevision.IsCurrent)
                 {
                     currentRevision = apiRevisionName;
-                    generateApiReleaseTemplate = true;
+                    generateSingleApiReleaseTemplate = true;
                 }
 
                 // creating a folder for this api revision
@@ -1029,7 +1029,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 Directory.CreateDirectory(revFileFolder);
                 revList.Add(apiRevisionName);
 
-                await this.GenerateTemplates(revFileFolder, singleApiName: apiRevisionName, generateApiReleaseTemplate: generateApiReleaseTemplate);
+                await this.GenerateTemplates(revFileFolder, singleApiName: apiRevisionName, generateSingleApiReleaseTemplate: generateSingleApiReleaseTemplate);
             }
 
             if (currentRevision is null)
@@ -1061,7 +1061,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             string singleApiName = null,
             List<string> multipleApiNames = null,
             Template<ApiTemplateResources> apiTemplate = null,
-            bool generateApiReleaseTemplate = false)
+            bool generateSingleApiReleaseTemplate = false)
         {
             if (!string.IsNullOrEmpty(singleApiName) && !multipleApiNames.IsNullOrEmpty())
             {
@@ -1072,7 +1072,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             // generate different templates using extractors and write to output
             apiTemplate = apiTemplate ?? await this.GenerateApiTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
             
-            if (generateApiReleaseTemplate == true)
+            if (generateSingleApiReleaseTemplate == true)
             {
                 await this.GenerateApiReleaseTemplateAsync(singleApiName, baseFilesGenerationDirectory);
             }

--- a/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
@@ -1037,7 +1037,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
 
                 await this.GenerateTemplates(revFileFolder, singleApiName: apiRevisionName);
                 
-                if (generateSingleApiReleaseTemplate == true)
+                if (generateSingleApiReleaseTemplate)
                 {
                     await this.GenerateApiReleaseTemplateAsync(apiRevisionName, revFileFolder);
                 }

--- a/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
@@ -1035,7 +1035,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 Directory.CreateDirectory(revFileFolder);
                 revList.Add(apiRevisionName);
 
-                await this.GenerateTemplates(revFileFolder, singleApiName: apiRevisionName, generateSingleApiReleaseTemplate: generateSingleApiReleaseTemplate);
+                await this.GenerateTemplates(revFileFolder, singleApiName: apiRevisionName);
+                
+                if (generateSingleApiReleaseTemplate == true)
+                {
+                    await this.GenerateApiReleaseTemplateAsync(apiRevisionName, revFileFolder);
+                }
             }
 
             if (currentRevision is null)
@@ -1066,8 +1071,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             string baseFilesGenerationDirectory,
             string singleApiName = null,
             List<string> multipleApiNames = null,
-            Template<ApiTemplateResources> apiTemplate = null,
-            bool generateSingleApiReleaseTemplate = false)
+            Template<ApiTemplateResources> apiTemplate = null)
         {
             if (!string.IsNullOrEmpty(singleApiName) && !multipleApiNames.IsNullOrEmpty())
             {
@@ -1078,11 +1082,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             // generate different templates using extractors and write to output
             apiTemplate = apiTemplate ?? await this.GenerateApiTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
             
-            if (generateSingleApiReleaseTemplate == true)
-            {
-                await this.GenerateApiReleaseTemplateAsync(singleApiName, baseFilesGenerationDirectory);
-            }
-
             var globalServicePolicyTemplate = await this.GeneratePolicyTemplateAsync(baseFilesGenerationDirectory);
             var productApiTemplate = await this.GenerateProductApisTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
             var productTemplate = await this.GenerateProductsTemplateAsync(singleApiName, baseFilesGenerationDirectory, apiTemplate.TypedResources.ApiProducts);

--- a/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
@@ -484,7 +484,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             Template<IdentityProviderResources> identityProviderTemplate = null,
             Template<SchemaTemplateResources> schemaTemplate = null,
             Template<OpenIdConnectProviderResources> openIdConnectProviderTemplate = null,
-            Template<PolicyFragmentsResources> policyFragmentsTemplate = null)
+            Template<PolicyFragmentsResources> policyFragmentsTemplate = null,
+            Template<ApiReleaseTemplateResources> apiReleaseTemplate = null)
         {
             this.RenameExistingParametersDirectory(baseFilesGenerationDirectory);
 
@@ -504,6 +505,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.SchemaParameters, schemaTemplate, mainParametersTemplate);
             await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.OpenIdConnectProvidersParameters, openIdConnectProviderTemplate, mainParametersTemplate);
             await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.PolicyFragmentsParameters, policyFragmentsTemplate, mainParametersTemplate);
+            await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.ApiReleaseParameters, apiReleaseTemplate, mainParametersTemplate);
         }
 
         public async Task GenerateResourceParametersFile<TTemplateResource>(string baseFilesGenerationDirectory, string fileName, Template<TTemplateResource> resourceTemplate, Template mainParametersTemplate) where TTemplateResource : ITemplateResources, new()
@@ -1171,10 +1173,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             var openIdConnectProviderTemplate = await this.GenerateOpenIdConnectProviderTemplateAsync(baseFilesGenerationDirectory);
             var schemasTempate = await this.GenerateSchemasTemplateAsync(baseFilesGenerationDirectory);
             var policyFragmentTemplate = await this.GeneratePolicyFragmentsTemplateAsync(apiTemplate.TypedResources.GetAllPolicies(), baseFilesGenerationDirectory);
+            var apiReleasesTemplate = await this.GenerateApiReleasesTemplateAsync(baseFilesGenerationDirectory);
             await this.GenerateGatewayTemplateAsync(singleApiName, baseFilesGenerationDirectory);
             await this.GenerateGatewayApiTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
             await this.GenerateApiManagementServiceTemplate(baseFilesGenerationDirectory);
-            await this.GenerateApiReleasesTemplateAsync(baseFilesGenerationDirectory);
+            
             var parametersTemplate = await this.GenerateParametersTemplateAsync(apisToExtract, loggerTemplate.TypedResources, backendTemplate.TypedResources, namedValueTemplate.TypedResources, identityProviderTemplate.TypedResources, openIdConnectProviderTemplate.TypedResources, baseFilesGenerationDirectory);
             
             await this.GenerateResourceParametersFiles(
@@ -1195,7 +1198,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 identityProviderTemplate: identityProviderTemplate,
                 openIdConnectProviderTemplate: openIdConnectProviderTemplate,
                 schemaTemplate: schemasTempate,
-                policyFragmentsTemplate: policyFragmentTemplate);
+                policyFragmentsTemplate: policyFragmentTemplate,
+                apiReleaseTemplate: apiReleasesTemplate);
 
             await this.GenerateMasterTemplateAsync(
                 baseFilesGenerationDirectory,

--- a/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
 
         readonly ILogger<ExtractorExecutor> logger;
         readonly IApisClient apisClient;
+        readonly IApiRevisionClient apiRevisionClient;
 
         readonly IApiExtractor apiExtractor;
         readonly IApiVersionSetExtractor apiVersionSetExtractor;
@@ -98,7 +99,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             ISchemaExtractor schemaExtractor,
             IOpenIdConnectProviderExtractor openIdConnectProviderExtractor,
             IPolicyFragmentsExtractor policyFragmentsExtractor,
-            IApiReleaseExtractor apiReleaseExtractor)
+            IApiReleaseExtractor apiReleaseExtractor,
+            IApiRevisionClient apiRevisionClient)
         {
             this.logger = logger;
             this.apisClient = apisClient;
@@ -125,6 +127,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             this.openIdConnectProviderExtractor = openIdConnectProviderExtractor;
             this.policyFragmentsExtractor = policyFragmentsExtractor;
             this.apiReleaseExtractor = apiReleaseExtractor;
+            this.apiRevisionClient = apiRevisionClient;
         }
 
         /// <summary>
@@ -156,7 +159,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             ISchemaExtractor schemaExtractor = null,
             IOpenIdConnectProviderExtractor openIdConnectProviderExtractor = null,
             IPolicyFragmentsExtractor policyFragmentsExtractor = null,
-            IApiReleaseExtractor apiReleaseExtractor = null)
+            IApiReleaseExtractor apiReleaseExtractor = null,
+            IApiRevisionClient apiRevisionClient = null)
         => new ExtractorExecutor(
                 logger,
                 apisClient,
@@ -182,7 +186,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 schemaExtractor,
                 openIdConnectProviderExtractor,
                 policyFragmentsExtractor,
-                apiReleaseExtractor);
+                apiReleaseExtractor,
+                apiRevisionClient);
 
         public void SetExtractorParameters(ExtractorParameters extractorParameters)
         {
@@ -1040,7 +1045,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             }
 
             var apisToExtract = await this.GetApiNamesToExtract(singleApiName, multipleApiNames);
-
             // generate different templates using extractors and write to output
             apiTemplate = apiTemplate ?? await this.GenerateApiTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
             

--- a/src/ArmTemplates/Common/API/Clients/Abstractions/IApisClient.cs
+++ b/src/ArmTemplates/Common/API/Clients/Abstractions/IApisClient.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
 
         Task<List<ApiTemplateResource>> GetAllAsync(ExtractorParameters extractorParameters);
 
+        Task<List<ApiTemplateResource>> GetAllCurrentAsync(ExtractorParameters extractorParameters);
+
         Task<List<ApiTemplateResource>> GetAllLinkedToProductAsync(string productName, ExtractorParameters extractorParameters);
 
         Task<List<ApiTemplateResource>> GetAllLinkedToGatewayAsync(string gatewayName, ExtractorParameters extractorParameters);

--- a/src/ArmTemplates/Common/API/Clients/Apis/ApisClient.cs
+++ b/src/ArmTemplates/Common/API/Clients/Apis/ApisClient.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.A
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilities.DataProcessors.Absctraction;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Apis
 {
@@ -17,11 +18,15 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
     {
         const string GetSingleApiRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}";
         const string GetAllApisRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?api-version={4}";
+        const string GetAllCurrentApisRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?api-version={4}&$filter=isCurrent";
         const string GetAllApisLinkedToProductRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/products/{4}/apis?api-version={5}";
         const string GetApisLinkedToGatewayRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/gateways/{4}/apis?api-version={5}";
 
-        public ApisClient(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        readonly IApiDataProcessor apiDataProcessor;
+
+        public ApisClient(IHttpClientFactory httpClientFactory, IApiDataProcessor apiDataProcessor) : base(httpClientFactory)
         {
+            this.apiDataProcessor = apiDataProcessor;
         }
 
         public async Task<ApiTemplateResource> GetSingleAsync(string apiName, ExtractorParameters extractorParameters)
@@ -30,7 +35,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
             string requestUrl = string.Format(GetSingleApiRequest,
                 this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, apiName, GlobalConstants.ApiVersion);
 
-            return await this.GetResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            var api = await this.GetResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            this.apiDataProcessor.ProcessSingleData(api);
+
+            return api;
         }
 
         public async Task<List<ApiTemplateResource>> GetAllAsync(ExtractorParameters extractorParameters)
@@ -40,7 +48,23 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
             string requestUrl = string.Format(GetAllApisRequest,
                 this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, GlobalConstants.ApiVersion);
 
-            return await this.GetPagedResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            var apis = await this.GetPagedResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            this.apiDataProcessor.ProcessData(apis);
+            
+            return apis;
+        }
+
+        public async Task<List<ApiTemplateResource>> GetAllCurrentAsync(ExtractorParameters extractorParameters)
+        {
+            var (azToken, azSubId) = await this.Auth.GetAccessToken();
+
+            string requestUrl = string.Format(GetAllCurrentApisRequest,
+                this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, GlobalConstants.ApiVersion);
+
+            var apis = await this.GetPagedResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            this.apiDataProcessor.ProcessData(apis);
+
+            return apis;
         }
 
         public async Task<List<ApiTemplateResource>> GetAllLinkedToProductAsync(string productName, ExtractorParameters extractorParameters)
@@ -49,7 +73,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
             string requestUrl = string.Format(GetAllApisLinkedToProductRequest,
                 this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, productName, GlobalConstants.ApiVersion);
 
-            return await this.GetPagedResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            var apis = await this.GetPagedResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            this.apiDataProcessor.ProcessData(apis);
+
+            return apis;
         }
 
         public async Task<List<ApiTemplateResource>> GetAllLinkedToGatewayAsync(string gatewayName, ExtractorParameters extractorParameters)
@@ -58,7 +85,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
             string requestUrl = string.Format(GetApisLinkedToGatewayRequest,
                 this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, gatewayName, GlobalConstants.ApiVersion);
 
-            return await this.GetPagedResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            var apis = await this.GetPagedResponseAsync<ApiTemplateResource>(azToken, requestUrl);
+            this.apiDataProcessor.ProcessData(apis);
+
+            return apis;
         }
     }
 }

--- a/src/ArmTemplates/Common/Extensions/NamingHelper.cs
+++ b/src/ArmTemplates/Common/Extensions/NamingHelper.cs
@@ -13,7 +13,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extension
     {
         static readonly Regex ExcludeOtherFromLettersAndDigitsRegex = new Regex("[^a-zA-Z0-9]");
         static readonly Regex ExcludeOtherFromAlphaNumericsAndHyphensRegex = new Regex("[^a-zA-Z0-9-]");
-        static readonly Regex ExcludeOtherFromValidDeploymentNameCharsRegex = new Regex(@"[^-\w\._\(\)]");
+
+        // ValidDeployment name is the string following the pattern: '^[-\w\._\(\)]+$'. https://docs.microsoft.com/en-us/rest/api/resources/deployments/create-or-update?tabs=HTTP#uri-parameters
+        // ExcludeOtherFromValidDeploymentNameCharsRegex matches any character other than [alphanumerics + '-' + '.' + '(' + ')' + '_'];
+        // Example: 'template;rev=1.json' string will match the ';' and '=' chars
+        static readonly Regex ExcludeOtherFromValidDeploymentNameCharsRegex = new Regex(@"[^-\w\._\(\)]"); 
 
         public static string GetSubstringBetweenTwoCharacters(char left, char right, string fullString)
         {

--- a/src/ArmTemplates/Common/Extensions/NamingHelper.cs
+++ b/src/ArmTemplates/Common/Extensions/NamingHelper.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extension
     {
         static readonly Regex ExcludeOtherFromLettersAndDigitsRegex = new Regex("[^a-zA-Z0-9]");
         static readonly Regex ExcludeOtherFromAlphaNumericsAndHyphensRegex = new Regex("[^a-zA-Z0-9-]");
+        static readonly Regex ValidDeploymentNameRegEx = new Regex("[^-\\w\\._\\(\\)]");
 
         public static string GetSubstringBetweenTwoCharacters(char left, char right, string fullString)
         {
@@ -59,6 +60,17 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extension
         public static string GenerateParametrizedResourceName(string parameterName, string resourceName)
         {
             return $"[concat(parameters('{parameterName}'), '/{resourceName}')]";
+        }
+
+        public static string GenerateValidDeploymentFileName(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return string.Empty;
+            }
+
+            var resourceName = ValidDeploymentNameRegEx.Replace(fileName, "-");
+            return resourceName;
         }
     }
 }

--- a/src/ArmTemplates/Common/Extensions/NamingHelper.cs
+++ b/src/ArmTemplates/Common/Extensions/NamingHelper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extension
     {
         static readonly Regex ExcludeOtherFromLettersAndDigitsRegex = new Regex("[^a-zA-Z0-9]");
         static readonly Regex ExcludeOtherFromAlphaNumericsAndHyphensRegex = new Regex("[^a-zA-Z0-9-]");
-        static readonly Regex ValidDeploymentNameRegEx = new Regex("[^-\\w\\._\\(\\)]");
+        static readonly Regex ExcludeOtherFromValidDeploymentNameCharsRegex = new Regex(@"[^-\w\._\(\)]");
 
         public static string GetSubstringBetweenTwoCharacters(char left, char right, string fullString)
         {
@@ -70,13 +70,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extension
                 return string.Empty;
             }
 
-            var resourceName = ValidDeploymentNameRegEx.Replace(fileName, "-");
+            var resourceName = ExcludeOtherFromValidDeploymentNameCharsRegex.Replace(fileName, "-");
             return resourceName;
         }
 
         public static string GenerateApisResourceId(string apiName)
         {
-            return $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]";
+            return $"[resourceId('{ResourceTypeConstants.API}', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]";
         }
     }
 }

--- a/src/ArmTemplates/Common/Extensions/NamingHelper.cs
+++ b/src/ArmTemplates/Common/Extensions/NamingHelper.cs
@@ -5,6 +5,7 @@
 
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions
 {
@@ -71,6 +72,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extension
 
             var resourceName = ValidDeploymentNameRegEx.Replace(fileName, "-");
             return resourceName;
+        }
+
+        public static string GenerateApisResourceId(string apiName)
+        {
+            return $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]";
         }
     }
 }

--- a/src/ArmTemplates/Common/FileHandlers/FileNameGenerator.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileNameGenerator.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
                 PolicyFragments = $@"{baseFileName}policy-fragments.template.json",
                 PolicyFragmentsParameters = "policy-fragments.parameters.json",
                 ApiRelease = $@"{baseFileName}api-release.template.json",
+                ApiReleaseParameters = $@"api-release.parameters.json",
                 Parameters = $@"{baseFileName}parameters.json",
                 LinkedMaster = $@"{baseFileName}master.template.json",
                 Apis = "/Apis",

--- a/src/ArmTemplates/Common/FileHandlers/FileNameGenerator.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileNameGenerator.cs
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License.
 // --------------------------------------------------------------------------
 
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
+
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandlers
 {
     public static class FileNameGenerator
@@ -39,6 +41,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
                 ApiManagementService = $@"{baseFileName}api-management-service.template.json",
                 TagApi = $@"{baseFileName}apiTags.template.json",
                 Schema = $@"{baseFileName}schemas.template.json",
+                ApiRelease = $@"{baseFileName}api-release.template.json",
                 Parameters = $@"{baseFileName}parameters.json",
                 LinkedMaster = $@"{baseFileName}master.template.json",
                 Apis = "/Apis",
@@ -68,7 +71,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
 
         public static string GenerateExtractorAPIFileName(string singleAPIName, string baseFileName)
         {
-            return singleAPIName == null ? $@"{baseFileName}apis.template.json" : $@"{baseFileName}{singleAPIName}-api.template.json";
+            return singleAPIName == null ? $@"{baseFileName}apis.template.json" : $@"{baseFileName}{NamingHelper.GenerateValidDeploymentFileName(singleAPIName)}-api.template.json";
         }
 
         public static string GenerateOriginalAPIName(string apiName)

--- a/src/ArmTemplates/Common/FileHandlers/FileNames.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileNames.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
 
         public string Schema { get; set; }
 
+        public string ApiRelease { get; set; }
+
         public string Parameters { get; set; }
         
         // linked property outputs 1 master template

--- a/src/ArmTemplates/Common/FileHandlers/FileNames.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileNames.cs
@@ -79,6 +79,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
 
         public string ApiRelease { get; set; }
 
+        public string ApiReleaseParameters { get; set; }
+
         public string Parameters { get; set; }
         
         // linked property outputs 1 master template

--- a/src/ArmTemplates/Common/Templates/ApiReleases/ApiReleaseProperties.cs
+++ b/src/ArmTemplates/Common/Templates/ApiReleases/ApiReleaseProperties.cs
@@ -1,0 +1,14 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiReleases
+{
+    public class ApiReleaseProperties
+    {
+        public string ApiId { get; set; }
+
+        public string Notes { get; set; }
+    }
+}

--- a/src/ArmTemplates/Common/Templates/ApiReleases/ApiReleaseTemplateResource.cs
+++ b/src/ArmTemplates/Common/Templates/ApiReleases/ApiReleaseTemplateResource.cs
@@ -1,0 +1,14 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiReleases
+{
+    public class ApiReleaseTemplateResource : TemplateResource
+    {
+        public ApiReleaseProperties Properties { get; set; }
+    }
+}

--- a/src/ArmTemplates/Common/Templates/ApiReleases/ApiReleaseTemplateResources.cs
+++ b/src/ArmTemplates/Common/Templates/ApiReleases/ApiReleaseTemplateResources.cs
@@ -1,0 +1,26 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiReleases
+{
+    public class ApiReleaseTemplateResources : ITemplateResources
+    {
+        public List<ApiReleaseTemplateResource> ApiReleases { get; set; } = new();
+
+        public TemplateResource[] BuildTemplateResources()
+        {
+            return this.ApiReleases.ToArray();
+        }
+
+        public bool HasContent()
+        {
+            return !this.ApiReleases.IsNullOrEmpty();
+        }
+    }
+}

--- a/src/ArmTemplates/Common/Templates/Apis/ApiProperties.cs
+++ b/src/ArmTemplates/Common/Templates/Apis/ApiProperties.cs
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License.
 // --------------------------------------------------------------------------
 
+using Newtonsoft.Json;
+
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis
 {
     public class ApiProperties
@@ -19,6 +21,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
 
         public string ApiVersion { get; set; }
 
+        [JsonIgnore]
         public bool? IsCurrent { get; set; }
 
         public string ApiRevisionDescription { get; set; }

--- a/src/ArmTemplates/Common/Templates/Apis/ApiProperties.cs
+++ b/src/ArmTemplates/Common/Templates/Apis/ApiProperties.cs
@@ -21,8 +21,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
 
         public string ApiVersion { get; set; }
 
-        [JsonIgnore]
         public bool? IsCurrent { get; set; }
+
+        [JsonIgnore]
+        public bool? LocalIsCurrent { get; set; }
 
         public string ApiRevisionDescription { get; set; }
 

--- a/src/ArmTemplates/Common/Templates/Apis/ApiProperties.cs
+++ b/src/ArmTemplates/Common/Templates/Apis/ApiProperties.cs
@@ -23,9 +23,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
 
         public bool? IsCurrent { get; set; }
 
-        [JsonIgnore]
-        public bool? LocalIsCurrent { get; set; }
-
         public bool? IsOnline { get; set; }
 
         public string ApiRevisionDescription { get; set; }

--- a/src/ArmTemplates/Common/Templates/Apis/ApiProperties.cs
+++ b/src/ArmTemplates/Common/Templates/Apis/ApiProperties.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
         [JsonIgnore]
         public bool? LocalIsCurrent { get; set; }
 
+        public bool? IsOnline { get; set; }
+
         public string ApiRevisionDescription { get; set; }
 
         public string ApiVersionDescription { get; set; }

--- a/src/ArmTemplates/Common/Templates/Apis/ApiTemplateResource.cs
+++ b/src/ArmTemplates/Common/Templates/Apis/ApiTemplateResource.cs
@@ -4,11 +4,15 @@
 // --------------------------------------------------------------------------
 
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis
 {
     public class ApiTemplateResource : TemplateResource
     {
+        [JsonIgnore]
+        public string OriginalName { get; set; }
+
         public ApiProperties Properties { get; set; }
     }
 }

--- a/src/ArmTemplates/Common/Templates/Apis/ApiTemplateResource.cs
+++ b/src/ArmTemplates/Common/Templates/Apis/ApiTemplateResource.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
         [JsonIgnore]
         public string OriginalName { get; set; }
 
+        [JsonIgnore]
+        public string ApiNameWithRevision { get; set; }
+
         public ApiProperties Properties { get; set; }
     }
 }

--- a/src/ArmTemplates/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/APIExtractor.cs
@@ -254,7 +254,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             }
 
             var apis = await this.apisClient.GetAllCurrentAsync(extractorParameters);
-            
+
+            if (apis.IsNullOrEmpty())
+            {
+                this.logger.LogWarning($"No current apis were found for '{extractorParameters.SourceApimName}' at '{extractorParameters.ResourceGroup}'");
+                return apiDependency;
+            }
+
             foreach (var api in apis)
             {
                 string apiName = api.OriginalName;

--- a/src/ArmTemplates/Extractor/EntityExtractors/APIExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/APIExtractor.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 }
 
                 this.logger.LogInformation("{0} API data found ...", singleApiName);
-                this.SetArmTemplateValuesToApiTemplateResource(apiResource, extractorParameters);
+                this.SetArmTemplateValuesToApiTemplateResource(singleApiName, apiResource, extractorParameters);
                 apiTemplateResources.Apis.Add(apiResource);
             }
             catch (Exception ex)
@@ -132,24 +132,22 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             return generalApiTemplateResourcesStorage;
         }
 
-        void SetArmTemplateValuesToApiTemplateResource(ApiTemplateResource apiResource, ExtractorParameters extractorParameters)
+        void SetArmTemplateValuesToApiTemplateResource(string apiName, ApiTemplateResource apiResource, ExtractorParameters extractorParameters)
         {
-            var originalServiceApiName = apiResource.Name;
-
-            apiResource.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{originalServiceApiName}')]";
+            apiResource.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}')]";
             apiResource.ApiVersion = GlobalConstants.ApiVersion;
             apiResource.Scale = null;
 
             if (extractorParameters.ParameterizeServiceUrl)
             {
-                apiResource.Properties.ServiceUrl = $"[parameters('{ParameterNames.ServiceUrl}').{NamingHelper.GenerateValidParameterName(originalServiceApiName, ParameterPrefix.Api)}]";
+                apiResource.Properties.ServiceUrl = $"[parameters('{ParameterNames.ServiceUrl}').{NamingHelper.GenerateValidParameterName(apiName, ParameterPrefix.Api)}]";
             }
 
             if (extractorParameters.ParametrizeApiOauth2Scope)
             {
                 if (apiResource.Properties.AuthenticationSettings?.OAuth2?.Scope is not null)
                 {
-                    apiResource.Properties.AuthenticationSettings.OAuth2.Scope = $"[parameters('{ParameterNames.ApiOauth2ScopeSettings}').{NamingHelper.GenerateValidParameterName(originalServiceApiName, ParameterPrefix.ApiOauth2Scope)}]";
+                    apiResource.Properties.AuthenticationSettings.OAuth2.Scope = $"[parameters('{ParameterNames.ApiOauth2ScopeSettings}').{NamingHelper.GenerateValidParameterName(apiName, ParameterPrefix.ApiOauth2Scope)}]";
                 }
             }
 

--- a/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IApiExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IApiExtractor.cs
@@ -18,7 +18,5 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         Task<ApiTemplateResources> GenerateSingleApiTemplateResourcesAsync(string singleApiName, string baseFilesGenerationDirectory, ExtractorParameters extractorParameters, string apiDepends = null);
 
         Task<ApiTemplateResources> GetApiRelatedTemplateResourcesAsync(string apiName, string baseFilesGenerationDirectory, ExtractorParameters extractorParameters);
-
-        Task<Dictionary<string, string>> GenerateApiRevisionDependencyStructure(ExtractorParameters extractorParameters);
     }
 }

--- a/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IApiExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IApiExtractor.cs
@@ -15,8 +15,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
     {
         Task<Template<ApiTemplateResources>> GenerateApiTemplateAsync(string singleApiName, List<string> multipleApiNames, string baseFilesGenerationDirectory, ExtractorParameters extractorParameters);
 
-        Task<ApiTemplateResources> GenerateSingleApiTemplateResourcesAsync(string singleApiName, string baseFilesGenerationDirectory, ExtractorParameters extractorParameters);
+        Task<ApiTemplateResources> GenerateSingleApiTemplateResourcesAsync(string singleApiName, string baseFilesGenerationDirectory, ExtractorParameters extractorParameters, string apiDepends = null);
 
         Task<ApiTemplateResources> GetApiRelatedTemplateResourcesAsync(string apiName, string baseFilesGenerationDirectory, ExtractorParameters extractorParameters);
+
+        Task<Dictionary<string, string>> GenerateApiRevisionDependencyStructure(ExtractorParameters extractorParameters);
     }
 }

--- a/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IApiReleaseExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IApiReleaseExtractor.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License.
 // --------------------------------------------------------------------------
 
+using System.Threading.Tasks;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiReleases;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
@@ -12,5 +13,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
     public interface IApiReleaseExtractor
     {
         Template<ApiReleaseTemplateResources> GenerateSingleApiReleaseTemplate(string apiName, ExtractorParameters extractorParameters);
+        
+        Task<Template<ApiReleaseTemplateResources>> GenerateCurrentApiReleaseTemplate(ExtractorParameters extractorParameters);
     }
 }

--- a/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IApiReleaseExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IApiReleaseExtractor.cs
@@ -1,0 +1,16 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiReleases;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors.Abstractions
+{
+    public interface IApiReleaseExtractor
+    {
+        Template<ApiReleaseTemplateResources> GenerateSingleApiReleaseTemplate(string apiName, ExtractorParameters extractorParameters);
+    }
+}

--- a/src/ArmTemplates/Extractor/EntityExtractors/ApiOperationExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ApiOperationExtractor.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 apiOperation.ApiVersion = GlobalConstants.ApiVersion;
                 apiOperation.Scale = null;
 
-                var operationDependsOn = new List<string>() { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
+                var operationDependsOn = new List<string>() { NamingHelper.GenerateApisResourceId(apiName) };
                 if (apiOperation.Properties?.Request?.Representations?.IsNullOrEmpty() == false)
                 {
                     foreach (var requestRepresentation in apiOperation.Properties.Request.Representations)

--- a/src/ArmTemplates/Extractor/EntityExtractors/ApiReleaseExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ApiReleaseExtractor.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiReleases;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders.Abstractions;
@@ -53,6 +54,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                                         .Build<ApiReleaseTemplateResources>();
 
             var apis = await this.apisClient.GetAllCurrentAsync(extractorParameters);
+
+            if (apis.IsNullOrEmpty())
+            {
+                this.logger.LogWarning($"No current apis were found for '{extractorParameters.SourceApimName}' at '{extractorParameters.ResourceGroup}'");
+                return apiReleasesTemplate;
+            }
 
             foreach (var api in apis)
             {

--- a/src/ArmTemplates/Extractor/EntityExtractors/ApiReleaseExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ApiReleaseExtractor.cs
@@ -1,0 +1,53 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiReleases;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors
+{
+    public class ApiReleaseExtractor : IApiReleaseExtractor
+    {
+        readonly ILogger<ApiReleaseExtractor> logger;
+        readonly ITemplateBuilder templateBuilder;
+
+        public ApiReleaseExtractor(
+            ILogger<ApiReleaseExtractor> logger,
+            ITemplateBuilder templateBuilder)
+        {
+            this.logger = logger;
+            this.templateBuilder = templateBuilder;
+        }
+
+        public Template<ApiReleaseTemplateResources> GenerateSingleApiReleaseTemplate(string apiName, ExtractorParameters extractorParameters)
+        {
+            var apiReleaseTemplate = this.templateBuilder
+                                        .GenerateTemplateWithApimServiceNameProperty()
+                                        .Build<ApiReleaseTemplateResources>();
+            var currentDatetime = DateTime.Now.ToString("hhmmssddMMyy");
+            var apiReleaseName = $"{currentDatetime}release";
+
+            var apiReleaseResource = new ApiReleaseTemplateResource
+            {
+                Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{apiReleaseName}')]",
+                Type = ResourceTypeConstants.APIRelease,
+                ApiVersion = GlobalConstants.ApiVersion,
+                Properties = new ApiReleaseProperties
+                {
+                    ApiId = $"/apis/{apiName}"
+                }
+            };
+            apiReleaseTemplate.TypedResources.ApiReleases.Add(apiReleaseResource);
+            
+            return apiReleaseTemplate;
+        }
+    }
+}

--- a/src/ArmTemplates/Extractor/EntityExtractors/ApiRevisionExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ApiRevisionExtractor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 {
                     var apiResources = await this.apiExtractor.GenerateSingleApiTemplateResourcesAsync(curApi, baseFilesGenerationDirectory, extractorParameters);
                     var apiResource = apiResources.Apis.FirstOrDefault();
-                    apiResource.DependsOn = new[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{extractorParameters.SingleApiName}')]" };
+                    apiResource.DependsOn = new[] { NamingHelper.GenerateApisResourceId(extractorParameters.SingleApiName) };
 
                     apiRevisionTemplate.TypedResources.AddResourcesData(apiResources);
                 }

--- a/src/ArmTemplates/Extractor/EntityExtractors/ApiRevisionExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ApiRevisionExtractor.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         readonly ILogger<ApiRevisionExtractor> logger;
         readonly ITemplateBuilder templateBuilder;
 
-        readonly IApisClient apisClient;
         readonly IApiRevisionClient apiRevisionClient;
 
         readonly IApiExtractor apiExtractor;
@@ -34,13 +33,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             ILogger<ApiRevisionExtractor> logger,
             ITemplateBuilder templateBuilder,
             IApiExtractor apiExtractor,
-            IApisClient apisClient,
             IApiRevisionClient apiRevisionClient)
         {
             this.logger = logger;
             this.templateBuilder = templateBuilder;
 
-            this.apisClient = apisClient;
             this.apiRevisionClient = apiRevisionClient;
 
             this.apiExtractor = apiExtractor;
@@ -91,52 +88,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             }
 
             return apiRevisionTemplate;
-        }
-
-        async Task<ApiTemplateResources> GenerateCurrentRevisionApiTemplateResourcesAsync(string apiName, string baseFilesGenerationDirectory, ExtractorParameters extractorParameters)
-        {
-            var apiTemplateResources = new ApiTemplateResources();
-
-            // gets the current revision of this api and will remove "isCurrent" paramter
-            var versionedApiResource = await this.GenerateApiTemplateResourceAsVersioned(apiName, extractorParameters);
-
-            apiTemplateResources.Apis.Add(versionedApiResource);
-            var relatedTemplateResources = await this.apiExtractor.GetApiRelatedTemplateResourcesAsync(apiName, baseFilesGenerationDirectory, extractorParameters);
-            apiTemplateResources.AddResourcesData(relatedTemplateResources);
-
-            return apiTemplateResources;
-        }
-
-        async Task<ApiTemplateResource> GenerateApiTemplateResourceAsVersioned(string apiName, ExtractorParameters extractorParameters)
-        {
-            var apiDetails = await this.apisClient.GetSingleAsync(apiName, extractorParameters);
-
-            apiDetails.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}')]";
-            apiDetails.ApiVersion = GlobalConstants.ApiVersion;
-            apiDetails.Scale = null;
-            apiDetails.Properties.IsCurrent = null;
-
-            if (extractorParameters.ParameterizeServiceUrl)
-            {
-                apiDetails.Properties.ServiceUrl = $"[parameters('{ParameterNames.ServiceUrl}').{NamingHelper.GenerateValidParameterName(apiName, ParameterPrefix.Api)}]";
-            }
-
-            if (apiDetails.Properties.ApiVersionSetId != null)
-            {
-                apiDetails.DependsOn = Array.Empty<string>();
-
-                string versionSetName = apiDetails.Properties.ApiVersionSetId;
-                int versionSetPosition = versionSetName.IndexOf("apiVersionSets/");
-
-                versionSetName = versionSetName.Substring(versionSetPosition, versionSetName.Length - versionSetPosition);
-                apiDetails.Properties.ApiVersionSetId = $"[concat(resourceId('Microsoft.ApiManagement/service', parameters('{ParameterNames.ApimServiceName}')), '/{versionSetName}')]";
-            }
-            else
-            {
-                apiDetails.DependsOn = Array.Empty<string>();
-            }
-
-            return apiDetails;
         }
     }
 }

--- a/src/ArmTemplates/Extractor/EntityExtractors/ApiSchemaExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ApiSchemaExtractor.cs
@@ -6,6 +6,7 @@
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiSchemas;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
@@ -38,7 +39,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 apiSchema.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{apiSchemaOriginalName}')]";
                 apiSchema.Type = ResourceTypeConstants.APISchema;
                 apiSchema.ApiVersion = GlobalConstants.ApiVersion;
-                apiSchema.DependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
+                apiSchema.DependsOn = new string[] { NamingHelper.GenerateApisResourceId(apiName) };
 
                 apiSchemaResources.ApiSchemas.Add(apiSchema);
             }

--- a/src/ArmTemplates/Extractor/EntityExtractors/DiagnosticExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/DiagnosticExtractor.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 apiDiagnostic.Type = ResourceTypeConstants.APIDiagnostic;
                 apiDiagnostic.ApiVersion = GlobalConstants.ApiVersion;
                 apiDiagnostic.Scale = null;
-                apiDiagnostic.DependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
+                apiDiagnostic.DependsOn = new string[] { NamingHelper.GenerateApisResourceId(apiName) };
 
                 if (extractorParameters.ParameterizeApiLoggerId)
                 {

--- a/src/ArmTemplates/Extractor/EntityExtractors/PolicyExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/PolicyExtractor.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 
             apiPolicy.ApiVersion = GlobalConstants.ApiVersion;
             apiPolicy.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{apiPolicyOriginalName}')]";
-            apiPolicy.DependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
+            apiPolicy.DependsOn = new string[] { NamingHelper.GenerateApisResourceId(apiName) };
 
             // write policy xml content to file and point to it if policyXMLBaseUrl is provided
             if (extractorParameters.PolicyXMLBaseUrl is not null)

--- a/src/ArmTemplates/Extractor/EntityExtractors/ProductApisExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ProductApisExtractor.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 
                 this.logger.LogInformation("{0} Product API found ...", singleApiName);
                 var dependsOnParameter = addDependsOnParameter
-                    ? new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{singleApiName}')]" }
+                    ? new string[] { NamingHelper.GenerateApisResourceId(singleApiName) }
                     : Array.Empty<string>();
 
                 return await this.GenerateProductApiTemplateResourcesAsync(singleApiName, extractorParameters, dependsOnParameter);

--- a/src/ArmTemplates/Extractor/EntityExtractors/TagExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/TagExtractor.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 apiTag.Name = $"[concat(parameters('{ParameterNames.ApimServiceName}'), '/{apiName}/{apiTagOriginalName}')]";
                 apiTag.ApiVersion = GlobalConstants.ApiVersion;
                 apiTag.Scale = null;
-                apiTag.DependsOn = new string[] { $"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{ParameterNames.ApimServiceName}'), '{apiName}')]" };
+                apiTag.DependsOn = new string[] { NamingHelper.GenerateApisResourceId(apiName) };
 
                 templateResources.Add(apiTag);
             }

--- a/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
+++ b/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             this.PolicyXMLBaseUrl = extractorConfig.PolicyXMLBaseUrl;
             this.PolicyXMLSasToken = extractorConfig.PolicyXMLSasToken;
             this.ApiVersionSetName = extractorConfig.ApiVersionSetName;
-            this.IncludeAllRevisions = extractorConfig.IncludeAllRevisions != null && extractorConfig.IncludeAllRevisions.Equals("true", StringComparison.OrdinalIgnoreCase);
             this.ParameterizeNamedValue = extractorConfig.ParamNamedValue != null && extractorConfig.ParamNamedValue.Equals("true", StringComparison.OrdinalIgnoreCase);
             this.ParameterizeApiLoggerId = extractorConfig.ParamApiLoggerId != null && extractorConfig.ParamApiLoggerId.Equals("true", StringComparison.OrdinalIgnoreCase);
             this.ParameterizeLogResourceId = extractorConfig.ParamLogResourceId != null && extractorConfig.ParamLogResourceId.Equals("true", StringComparison.OrdinalIgnoreCase);

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/Absctraction/IApiDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/Absctraction/IApiDataProcessor.cs
@@ -1,0 +1,17 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilities.DataProcessors.Absctraction
+{
+    public interface IApiDataProcessor
+    {
+        void ProcessData(List<ApiTemplateResource> apis);
+        void ProcessSingleData(ApiTemplateResource api);
+    }
+}

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
 {
     public class ApiDataProcessor : IApiDataProcessor
     {
-
         public void ProcessData(List<ApiTemplateResource> apis)
         {
             if (apis.IsNullOrEmpty())

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
         public void ProcessSingleData(ApiTemplateResource api)
         {
             api.OriginalName = api.Name;
-            api.Properties.LocalIsCurrent = api.Properties.IsCurrent;
+            var isCurent = api.Properties.IsCurrent;
             api.Properties.IsCurrent = null;
 
-            if (api.Properties.LocalIsCurrent == true && !string.IsNullOrEmpty(api.Properties.ApiRevision))
+            if (isCurent == true && !string.IsNullOrEmpty(api.Properties.ApiRevision))
             {
                 api.ApiNameWithRevision = $"{api.Name};rev={api.Properties.ApiRevision}";
                 if (!api.Name.Contains($";rev={api.Properties.ApiRevision}"))

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
@@ -34,11 +34,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
 
             if (api.Properties.LocalIsCurrent == true && !string.IsNullOrEmpty(api.Properties.ApiRevision))
             {
-                if (!api.Properties.ApiRevision.Equals("1") && !api.Name.Contains($";rev={api.Properties.ApiRevision}"))
+                api.ApiNameWithRevision = $"{api.Name};rev={api.Properties.ApiRevision}";
+                if (!api.Name.Contains($";rev={api.Properties.ApiRevision}"))
                 {
                     api.Name = $"{api.Name};rev={api.Properties.ApiRevision}";
                 }
             }
+
         }
     }
 }

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
                     api.Name = $"{api.Name};rev={api.Properties.ApiRevision}";
                 }
             }
-
         }
     }
 }

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
         public void ProcessSingleData(ApiTemplateResource api)
         {
             api.OriginalName = api.Name;
-            var isCurent = api.Properties.IsCurrent;
+            var isCurrent = api.Properties.IsCurrent;
             api.Properties.IsCurrent = null;
 
-            if (isCurent == true && !string.IsNullOrEmpty(api.Properties.ApiRevision))
+            if (isCurrent == true && !string.IsNullOrEmpty(api.Properties.ApiRevision))
             {
                 api.ApiNameWithRevision = $"{api.Name};rev={api.Properties.ApiRevision}";
                 if (!api.Name.Contains($";rev={api.Properties.ApiRevision}"))

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/ApiDataProcessor.cs
@@ -1,0 +1,44 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilities.DataProcessors.Absctraction;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilities.DataProcessors
+{
+    public class ApiDataProcessor : IApiDataProcessor
+    {
+
+        public void ProcessData(List<ApiTemplateResource> apis)
+        {
+            if (apis.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            foreach (var api in apis)
+            {
+                this.ProcessSingleData(api);
+            }
+        }
+
+        public void ProcessSingleData(ApiTemplateResource api)
+        {
+            api.OriginalName = api.Name;
+            api.Properties.LocalIsCurrent = api.Properties.IsCurrent;
+            api.Properties.IsCurrent = null;
+
+            if (api.Properties.LocalIsCurrent == true && !string.IsNullOrEmpty(api.Properties.ApiRevision))
+            {
+                if (!api.Properties.ApiRevision.Equals("1") && !api.Name.Contains($";rev={api.Properties.ApiRevision}"))
+                {
+                    api.Name = $"{api.Name};rev={api.Properties.ApiRevision}";
+                }
+            }
+        }
+    }
+}

--- a/src/ArmTemplates/ServiceExtensions.cs
+++ b/src/ArmTemplates/ServiceExtensions.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates
             services.AddScoped<IApiManagementServiceExtractor, ApiManagementServiceExtractor>();
             services.AddScoped<ISchemaExtractor, SchemaExtractor>();
             services.AddScoped<IOpenIdConnectProviderExtractor, OpenIdConnectProviderExtractor>();
+            services.AddScoped<IApiReleaseExtractor, ApiReleaseExtractor>();
         }
 
         static void SetupApiClients(IServiceCollection services)

--- a/src/ArmTemplates/ServiceExtensions.cs
+++ b/src/ArmTemplates/ServiceExtensions.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates
             services.AddScoped<ISchemaDataProcessor, SchemaDataProcessor>();
             services.AddScoped<IOpenIdConnectProviderProcessor, OpenIdConnectProviderProcessor>();
             services.AddScoped<IPolicyFragmentDataProcessor, PolicyFragmentDataProcessor>();
+            services.AddScoped<IApiDataProcessor, ApiDataProcessor>();
         }
 
         static void SetupCommands(IServiceCollection services)

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorTests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             var mockedTagClient = MockTagClient.GetMockedApiClientWithDefaultValues();
             var mockedApiOperationClient = MockApiOperationClient.GetMockedApiClientWithDefaultValues();
             var mockedDiagnosticClient = MockDiagnosticClient.GetMockedClientWithApiDependentValues();
+            var mockedRevisionClient = MockApisRevisionsClient.GetMockedApiRevisionClientWithDefaultValues();
 
             // mocked extractors
             var mockedDiagnosticExtractor = new DiagnosticExtractor(this.GetTestLogger<DiagnosticExtractor>(), mockedDiagnosticClient);
@@ -84,7 +85,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 mockedPolicyExtractor,
                 mockedProductApisExtractor,
                 mockedTagExtractor,
-                mockedApiOperationExtractor);
+                mockedApiOperationExtractor,
+                mockedRevisionClient
+                );
 
             var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
                 this.GetTestLogger<ExtractorExecutor>(),
@@ -184,6 +187,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             var mockedTagClient = MockTagClient.GetMockedApiClientWithDefaultValues();
             var mockedApiOperationClient = MockApiOperationClient.GetMockedApiClientWithDefaultValues();
             var mockedDiagnosticClient = MockDiagnosticClient.GetMockedClientWithApiDependentValues();
+            var mockedRevisionClient = MockApisRevisionsClient.GetMockedApiRevisionClientWithDefaultValues();
 
             // mocked extractors
             var mockedDiagnosticExtractor = new DiagnosticExtractor(this.GetTestLogger<DiagnosticExtractor>(), mockedDiagnosticClient);
@@ -202,7 +206,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 mockedPolicyExtractor,
                 mockedProductApisExtractor,
                 mockedTagExtractor,
-                mockedApiOperationExtractor);
+                mockedApiOperationExtractor,
+                mockedRevisionClient);
 
             var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
                 this.GetTestLogger<ExtractorExecutor>(),

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiReleaseExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiReleaseExtractorTests.cs
@@ -1,0 +1,58 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Scenarios
+{
+    [Trait("Category", "Api Release Extraction")]
+    public class ApiReleaseExtractorTests : ExtractorMockerWithOutputTestsBase
+    {
+        public ApiReleaseExtractorTests() : base("api-release-tests")
+        {
+        }
+
+        [Fact]
+        public async Task GenerateApiReleaseTemplateAsync_ProperlyCreatesTemplate()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateApiReleaseTemplateAsync_ProperlyCreatesTemplate));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration();
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            // mocked extractors
+            var apiReleaseExtractor = new ApiReleaseExtractor(this.GetTestLogger<ApiReleaseExtractor>(), new TemplateBuilder());
+            
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                apiReleaseExtractor: apiReleaseExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            var apiId = "api1;rev=2";
+
+            // act
+            var apiReleaseTemplate = await extractorExecutor.GenerateApiReleaseTemplateAsync(apiId, currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.ApiRelease)).Should().BeTrue();
+
+            apiReleaseTemplate.TypedResources.ApiReleases.Count().Should().Be(1);
+            var apiRelease = apiReleaseTemplate.TypedResources.ApiReleases[0];
+
+            apiRelease.Properties.Should().NotBeNull();
+            apiRelease.Properties.ApiId.Should().Be($"/apis/{apiId}");
+        }
+    }
+}

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiReleaseExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiReleaseExtractorTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             var extractorParameters = new ExtractorParameters(extractorConfig);
 
             // mocked extractors
-            var apiReleaseExtractor = new ApiReleaseExtractor(this.GetTestLogger<ApiReleaseExtractor>(), new TemplateBuilder());
+            var apiReleaseExtractor = new ApiReleaseExtractor(this.GetTestLogger<ApiReleaseExtractor>(), new TemplateBuilder(), null);
             
             var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
                 this.GetTestLogger<ExtractorExecutor>(),

--- a/tests/ArmTemplates.Tests/Extractor/Utilities/ApiDataProcessorTest.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Utilities/ApiDataProcessorTest.cs
@@ -1,0 +1,66 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilities.DataProcessors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Utilities
+{
+    public class ApiDataProcessorTest : ExtractorMockerTestsBase
+    {
+        public List<ApiTemplateResource> GetMockedApiTemplates() {
+            return new List<ApiTemplateResource>
+                {
+                    new ApiTemplateResource
+                    {
+                        Name = "api1",
+                        Type = ResourceTypeConstants.API,
+                        Properties = new ApiProperties
+                        {
+                            DisplayName = "Unlimited",
+                            Description = "unlimited description",
+                            ApiRevision = "1",
+                            IsCurrent = true,
+                        }
+                    },
+
+                    new ApiTemplateResource
+                    {
+                        Name = "api1;rev=2",
+                        Type = ResourceTypeConstants.API,
+                        Properties = new ApiProperties
+                        {
+                            DisplayName = "Unlimited",
+                            Description = "unlimited description",
+                            ApiRevision = "2"
+                        }
+                    },
+                };
+        }
+
+        [Fact]
+        public void TestApiDataProcess()
+        {
+            var apiTemplates = this.GetMockedApiTemplates();
+
+            var apiDataProcessor = new ApiDataProcessor();
+
+            apiDataProcessor.ProcessData(apiTemplates);
+
+            apiTemplates.ElementAt(0).Name.Should().BeEquivalentTo("api1;rev=1");
+            apiTemplates.ElementAt(0).ApiNameWithRevision.Should().BeEquivalentTo("api1;rev=1");
+            apiTemplates.ElementAt(0).Properties.LocalIsCurrent.Should().BeTrue();
+
+            apiTemplates.ElementAt(1).Name.Should().BeEquivalentTo("api1;rev=2");
+            apiTemplates.ElementAt(1).Properties.LocalIsCurrent.Should().BeNull();
+        }
+    }
+}

--- a/tests/ArmTemplates.Tests/Extractor/Utilities/ApiDataProcessorTest.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Utilities/ApiDataProcessorTest.cs
@@ -57,10 +57,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
 
             apiTemplates.ElementAt(0).Name.Should().BeEquivalentTo("api1;rev=1");
             apiTemplates.ElementAt(0).ApiNameWithRevision.Should().BeEquivalentTo("api1;rev=1");
-            apiTemplates.ElementAt(0).Properties.LocalIsCurrent.Should().BeTrue();
 
             apiTemplates.ElementAt(1).Name.Should().BeEquivalentTo("api1;rev=2");
-            apiTemplates.ElementAt(1).Properties.LocalIsCurrent.Should().BeNull();
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisClient.cs
@@ -4,9 +4,12 @@
 // --------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Apis;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilities.DataProcessors;
 using Moq;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients
@@ -145,6 +148,15 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                 });
 
             return mockedApisClient.Object;
+        }
+
+        public static async Task<IApisClient> GetMockedHttpApiClient(string responseFileLocation)
+        {
+            var apiDataProcessor = new ApiDataProcessor();
+            var mockedClient = new Mock<ApisClient>(MockBehavior.Strict, await MockClientUtils.GenerateMockedIHttpClientFactoryWithResponse(responseFileLocation), apiDataProcessor);
+            MockClientUtils.MockAuthOfApiClient(mockedClient);
+
+            return mockedClient.Object;
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisClient.cs
@@ -58,12 +58,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
 
         public static IApisClient GetMockedApiClientWithDefaultValues()
         {
-            var mockServiceApiProductsApiClient = new Mock<IApisClient>(MockBehavior.Strict);
+            var mockedApisClient = new Mock<IApisClient>(MockBehavior.Strict);
 
             var serviceProperties1 = GetMockedServiceApiProperties1();
             var serviceProperties2 = GetMockedServiceApiProperties2();
 
-            mockServiceApiProductsApiClient
+            mockedApisClient
                 .Setup(x => x.GetAllAsync(It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync((ExtractorParameters _) => new List<ApiTemplateResource>
                 {
@@ -82,7 +82,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                     },
                 });
 
-            mockServiceApiProductsApiClient
+            mockedApisClient
+                .Setup(x => x.GetAllCurrentAsync(It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync((ExtractorParameters _) => new List<ApiTemplateResource>
+                {
+                });
+
+            mockedApisClient
                 .Setup(x => x.GetAllLinkedToGatewayAsync(It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync((string gatewayName, ExtractorParameters _) => new List<ApiTemplateResource>
                 {
@@ -101,7 +107,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                     },
                 });
 
-            mockServiceApiProductsApiClient
+            mockedApisClient
                 .Setup(x => x.GetSingleAsync(It.Is<string>((o => o.Equals(ServiceApiName1))), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync((string _, ExtractorParameters _) => new ApiTemplateResource
                 {
@@ -110,7 +116,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                     Properties = serviceProperties1
                 });
 
-            mockServiceApiProductsApiClient
+            mockedApisClient
                 .Setup(x => x.GetSingleAsync(It.Is<string>((o => o.Equals(ServiceApiName2))), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync((string _, ExtractorParameters _) => new ApiTemplateResource
                 {
@@ -119,7 +125,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                     Properties = serviceProperties2
                 });
 
-            mockServiceApiProductsApiClient
+            mockedApisClient
                 .Setup(x => x.GetAllLinkedToProductAsync(It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync((string productName, ExtractorParameters _) => new List<ApiTemplateResource>
                 {
@@ -138,7 +144,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
                     }
                 });
 
-            return mockServiceApiProductsApiClient.Object;
+            return mockedApisClient.Object;
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisRevisionsClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisRevisionsClient.cs
@@ -1,0 +1,31 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiRevisions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Moq;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients
+{
+    public class MockApisRevisionsClient
+    {   
+        public static IApiRevisionClient GetMockedApiRevisionClientWithDefaultValues()
+        {
+            var mockApiRevisionClient = new Mock<IApiRevisionClient>(MockBehavior.Loose);
+
+            mockApiRevisionClient
+                .Setup(x => x.GetApiRevisionsAsync(It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new List<ApiRevisionTemplateResource>
+                {
+                    new ApiRevisionTemplateResource(),
+                    new ApiRevisionTemplateResource()
+                });
+
+            return mockApiRevisionClient.Object;
+        }
+    }
+}

--- a/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagementListApis_success_response.json
+++ b/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagementListApis_success_response.json
@@ -1,0 +1,66 @@
+{
+  "value": [
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/a1",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "a1",
+      "properties": {
+        "displayName": "api1",
+        "apiRevision": "1",
+        "serviceUrl": "http://echoapi.cloudapp.net/api",
+        "path": "api1",
+        "protocols": [
+          "https"
+        ],
+        "isCurrent": true,
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/5a73933b8f27f7cc82a2d533",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "5a73933b8f27f7cc82a2d533",
+      "properties": {
+        "displayName": "api1",
+        "apiRevision": "1",
+        "serviceUrl": "http://echoapi.cloudapp.net/api",
+        "path": "api1",
+        "protocols": [
+          "https"
+        ],
+        "isCurrent": true,
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/echo-api",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "echo-api",
+      "properties": {
+        "displayName": "Echo API",
+        "apiRevision": "1",
+        "serviceUrl": "http://echoapi.cloudapp.net/api",
+        "path": "echo",
+        "protocols": [
+          "https"
+        ],
+        "isCurrent": true
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/5a7390baa5816a110435aee0",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "5a7390baa5816a110435aee0",
+      "properties": {
+        "displayName": "Swagger Petstore Extensive",
+        "apiRevision": "1",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+        "serviceUrl": "http://petstore.swagger.wordnik.com/api",
+        "path": "vvv",
+        "protocols": [
+          "https"
+        ],
+        "isCurrent": true
+      }
+    }
+  ],
+  "count": 4,
+}


### PR DESCRIPTION
Release template added.
IsCurrent property removed from ApiProperties
IsOnline property added to ApiProperties
Add basic test for api release

**Breaking changes**
Filename changed for apis which are generated by default (it was not deployable on it is own) due to the name validation
