### PR TITLE
Exclude builtIn groups from groupTemplate via config parameter

### DIFF
--- a/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
+++ b/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
@@ -109,6 +109,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configu
         [Option(longName: "parametersOutputDirectoryName ", HelpText = "Parameters output directory name, by default it is \"parameters\"")]
         public string ParametersOutputDirectoryName { get; set; }
 
+        [Option(longName: "excludeBuildInGroups ", HelpText = "Excludes built-in groups from generated template if set to \"true\"")]
+        public string ExcludeBuildInGroups { get; set; }
+
         /// <summary>
         /// Api parameter properties for overriding Api OAuth2 scope or/and Service urloverride. Available via extractor-config file only.
         /// </summary>

--- a/src/ArmTemplates/Common/API/Clients/Groups/GroupsClient.cs
+++ b/src/ArmTemplates/Common/API/Clients/Groups/GroupsClient.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
                 this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, GlobalConstants.ApiVersion);
 
             var groupTemplates = await this.GetPagedResponseAsync<GroupTemplateResource>(azToken, requestUrl);
-            this.groupDataProcessor.ProcessData(groupTemplates, extractorParameters);
+            this.groupDataProcessor.ProcessDataAllGroups(groupTemplates, extractorParameters);
 
             return groupTemplates;
         }
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
                 this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, productName, GlobalConstants.ApiVersion);
 
             var groupTemplates = await this.GetPagedResponseAsync<GroupTemplateResource>(azToken, requestUrl);
-            this.groupDataProcessor.ProcessData(groupTemplates, extractorParameters);
+            this.groupDataProcessor.ProcessDataProductLinkedGroups(groupTemplates, extractorParameters);
 
             return groupTemplates;
         }

--- a/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
+++ b/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
@@ -90,6 +90,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
 
         public bool ExtractIdentityProviders { get; set; }
 
+        public bool ExcludeBuildInGroups { get; set; }
+
         public string ParametersOutputDirectoryName { get; set; }
 
         public Dictionary<string, ApiParameterProperty> ApiParameters { get; private set; }
@@ -126,7 +128,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             this.ParametrizeApiOauth2Scope = (extractorConfig.ParamApiOauth2Scope != null && extractorConfig.ParamApiOauth2Scope.Equals("true", StringComparison.OrdinalIgnoreCase)) || (extractorConfig.ApiParameters != null && extractorConfig.ApiParameters.Any(x => x.Value.Oauth2Scope is not null));
             this.ExtractSecrets = extractorConfig.ExtractSecrets != null && extractorConfig.ExtractSecrets.Equals("true", StringComparison.OrdinalIgnoreCase);
             this.ExtractIdentityProviders = extractorConfig.ExtractIdentityProviders != null && extractorConfig.ExtractIdentityProviders.Equals("true", StringComparison.OrdinalIgnoreCase);
-            
+            this.ExcludeBuildInGroups = extractorConfig.ExcludeBuildInGroups != null && extractorConfig.ExcludeBuildInGroups.Equals("true", StringComparison.OrdinalIgnoreCase);
+
             this.ParametersOutputDirectoryName = extractorConfig.ParametersOutputDirectoryName;
             if (!string.IsNullOrEmpty(extractorConfig.ParametersOutputDirectoryName))
             {
@@ -166,6 +169,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
             this.ExtractGateways = !string.IsNullOrEmpty(overridingConfig.ExtractGateways) ? overridingConfig.ExtractGateways.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ExtractGateways;
             this.ParametrizeApiOauth2Scope = !string.IsNullOrEmpty(overridingConfig.ParamApiOauth2Scope) ? overridingConfig.ParamApiOauth2Scope.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ParametrizeApiOauth2Scope;
             this.ExtractIdentityProviders = !string.IsNullOrEmpty(overridingConfig.ExtractIdentityProviders) ? overridingConfig.ExtractIdentityProviders.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ExtractIdentityProviders;
+            this.ExcludeBuildInGroups = !string.IsNullOrEmpty(overridingConfig.ExcludeBuildInGroups) ? overridingConfig.ExcludeBuildInGroups.Equals("true", StringComparison.OrdinalIgnoreCase) : this.ExcludeBuildInGroups;
 
             if (!string.IsNullOrEmpty(overridingConfig.BaseFileName))
             {

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/Absctraction/IGroupDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/Absctraction/IGroupDataProcessor.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
 {
     public interface IGroupDataProcessor
     {
-        void ProcessData(List<GroupTemplateResource> templates, ExtractorParameters extractorParameters);
+        void ProcessDataProductLinkedGroups(List<GroupTemplateResource> templates, ExtractorParameters extractorParameters);
 
-        void OverrideName(GroupTemplateResource template);
+        void ProcessDataAllGroups(List<GroupTemplateResource> templates, ExtractorParameters extractorParameters);
     }
 }

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/GroupDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/GroupDataProcessor.cs
@@ -25,14 +25,28 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
             };
         }
 
-        public void ProcessData(List<GroupTemplateResource> groupTemplates, ExtractorParameters extractorParameters)
+        public void ProcessDataAllGroups(List<GroupTemplateResource> groupTemplates, ExtractorParameters extractorParameters)
+        {
+            this.OverrideNames(groupTemplates, extractorParameters);
+            if (extractorParameters.ExcludeBuildInGroups)
+            {
+                groupTemplates.RemoveAll(x => x.Properties.BuiltIn);
+            }
+        }
+
+        public void ProcessDataProductLinkedGroups(List<GroupTemplateResource> groupTemplates, ExtractorParameters extractorParameters)
+        {
+            this.OverrideNames(groupTemplates, extractorParameters);
+        }
+
+        void OverrideNames(List<GroupTemplateResource> groupTemplates, ExtractorParameters extractorParameters)
         {
             if (groupTemplates.IsNullOrEmpty())
             {
                 return;
             }
 
-            foreach (var groupTemplate in groupTemplates) 
+            foreach (var groupTemplate in groupTemplates)
             {
                 groupTemplate.OriginalName = groupTemplate.Name;
                 groupTemplate.NewName = groupTemplate.Name;
@@ -44,7 +58,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
             }
         }
 
-        public void OverrideName(GroupTemplateResource template)
+        void OverrideName(GroupTemplateResource template)
         {
             if (this.OverrideRules.IsNullOrEmpty())
             {

--- a/src/ArmTemplates/Extractor/Utilities/DataProcessors/GroupDataProcessor.cs
+++ b/src/ArmTemplates/Extractor/Utilities/DataProcessors/GroupDataProcessor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Utilit
             this.OverrideNames(groupTemplates, extractorParameters);
             if (extractorParameters.ExcludeBuildInGroups)
             {
-                groupTemplates.RemoveAll(x => x.Properties.BuiltIn);
+                groupTemplates?.RemoveAll(x => x.Properties.BuiltIn);
             }
         }
 

--- a/src/README.md
+++ b/src/README.md
@@ -448,6 +448,7 @@ You have two choices when specifying your settings:
 | exctractSecrets  | No                    | By default false. If set to "true" secrets will be extracted as well and parameters templated will be supplied with actual secret values. Currently applies to identityProvider service.  |
 | extractIdentityProviders | No | By default false. Set to true will attempt to extract the identity providers from service. |
 | parametersOutputDirectoryName | No | If set will redefine the output folder name for parameters. By default will be equal to {service-name}-parameters |
+| excludeBuildInGroups | No | By default false. Set to true will exclude builtIn groups from groupsTemplate. |
 
 
 #### Note

--- a/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Abstractions/ExtractorMockerTestsBase.cs
@@ -112,7 +112,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                string paramApiOauth2Scope = null,
                Dictionary<string, ApiParameterProperty> apiParameters = null,
                string extractSecrets = null,
-               string extractIdentityProviders = null
+               string extractIdentityProviders = null,
+               string excludeBuildInGroups = null
          )
         {
 
@@ -148,7 +149,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 ParamApiOauth2Scope = paramApiOauth2Scope,
                 ApiParameters = apiParameters,
                 ExtractSecrets = extractSecrets,
-                ExtractIdentityProviders = extractIdentityProviders
+                ExtractIdentityProviders = extractIdentityProviders,
+                ExcludeBuildInGroups = excludeBuildInGroups
             };
         }
     }

--- a/tests/ArmTemplates.Tests/Extractor/Utilities/GroupDataProcessorTest.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Utilities/GroupDataProcessorTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
         }
 
         [Fact]
-        public void TestOverrideName()
+        public void TestProcessDataAllGroups_OverrideName()
         {
             var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(overrideGroupGuids: "true");
             var extractorParameters = new ExtractorParameters(extractorConfig);
@@ -58,14 +58,14 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
 
             var groupDataProcessor = new GroupDataProcessor();
 
-            groupDataProcessor.ProcessData(groupTemplates, extractorParameters);
+            groupDataProcessor.ProcessDataAllGroups(groupTemplates, extractorParameters);
 
             groupTemplates.ElementAt(0).Name.Should().BeEquivalentTo("administrators");
             groupTemplates.ElementAt(1).Name.Should().BeEquivalentTo("developers");
         }
 
         [Fact]
-        public void TestSkipOverrideName()
+        public void TestProcessDataAllGroups_SkipOverrideName()
         {
             var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(overrideGroupGuids: "false");
             var extractorParameters = new ExtractorParameters(extractorConfig);
@@ -73,10 +73,55 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             var groupDataProcessor = new GroupDataProcessor();
             
             var groupTemplates = this.GetMockGroupTemplates();
-            groupDataProcessor.ProcessData(groupTemplates, extractorParameters);
+            groupDataProcessor.ProcessDataAllGroups(groupTemplates, extractorParameters);
 
             groupTemplates.ElementAt(0).Name.Should().BeEquivalentTo("guid-administrators");
             groupTemplates.ElementAt(1).Name.Should().BeEquivalentTo("guid-developers");
+        }
+
+        [Fact]
+        public void TestProcessDataProductLinkedGroups_OverrideName()
+        {
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(overrideGroupGuids: "true");
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var groupTemplates = this.GetMockGroupTemplates();
+
+            var groupDataProcessor = new GroupDataProcessor();
+
+            groupDataProcessor.ProcessDataAllGroups(groupTemplates, extractorParameters);
+
+            groupTemplates.ElementAt(0).Name.Should().BeEquivalentTo("administrators");
+            groupTemplates.ElementAt(1).Name.Should().BeEquivalentTo("developers");
+        }
+
+        [Fact]
+        public void TestProcessDataProductLinkedGroups_SkipOverrideName()
+        {
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(overrideGroupGuids: "false");
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var groupDataProcessor = new GroupDataProcessor();
+
+            var groupTemplates = this.GetMockGroupTemplates();
+            groupDataProcessor.ProcessDataAllGroups(groupTemplates, extractorParameters);
+
+            groupTemplates.ElementAt(0).Name.Should().BeEquivalentTo("guid-administrators");
+            groupTemplates.ElementAt(1).Name.Should().BeEquivalentTo("guid-developers");
+        }
+
+        [Fact]
+        public void TestExcludeBuiltInGroups()
+        {
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(excludeBuildInGroups: "true");
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var groupDataProcessor = new GroupDataProcessor();
+
+            var groupTemplates = this.GetMockGroupTemplates();
+            groupDataProcessor.ProcessDataAllGroups(groupTemplates, extractorParameters);
+
+            groupTemplates.Count.Should().Be(0);
         }
     }
 }


### PR DESCRIPTION
New parameter added, when set to true will exclude builtin groups from generated template.
Closes #776 