### PR TITLE
Extract tag if attached to Api level tags

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/TagExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/TagExtractor.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 // or if it is found in tags associated with the products associated with the api
                 if (string.IsNullOrEmpty(singleApiName)
                         || apiOperationTagResources.Any(t => t.Name.Contains($"/{tagOriginalName}'"))
+                        || apiTemplateResources.Tags.Any(t => t.Name.Contains($"/{tagOriginalName}'"))
                         || productAPIResources.Any(t => t.Name.Contains($"/{singleApiName}"))
                             && productTagResources.Any(t => t.Name.Contains($"/{tagOriginalName}'")))
                 {

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/TagExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/TagExtractorTests.cs
@@ -130,7 +130,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             resources.Tags.Any(x => x.Name.Contains(MockTagClient.OperationTagName2)).Should().BeTrue();
         }
 
-
         [Fact]
         public async Task GenerateTagTemplates_GetApiRelatedTags_ProperlyLaysTheInformation()
         {

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/TagExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/TagExtractorTests.cs
@@ -150,32 +150,32 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 tagExtractor: tagExtractor);
             extractorExecutor.SetExtractorParameters(extractorParameters);
 
-            ApiTemplateResources apiTemplateResources = new ApiTemplateResources()
+            var apiTemplateResources = new ApiTemplateResources
             {
-                Tags = new List<TagTemplateResource>()
+                Tags = new List<TagTemplateResource>
                 {
-                    new TagTemplateResource()
+                    new TagTemplateResource
                     {
                         Name = $"parameters'/{MockTagClient.TagName1}'"
                     },
-                    new TagTemplateResource()
+                    new TagTemplateResource
                     {
                         Name = $"parameters/{MockTagClient.TagName2}'"
                     }
                 },
-                ApiOperationsTags = new List<TagTemplateResource>()
+                ApiOperationsTags = new List<TagTemplateResource>
                 {
-                    new TagTemplateResource()
+                    new TagTemplateResource
                     {
                         Name = $"parameters'/{MockTagClient.OperationTagName1}'"
                     },
-                    new TagTemplateResource()
+                    new TagTemplateResource
                     {
                         Name = $"parameters/{MockTagClient.OperationTagName2}'"
                     }
                 }
             };
-            ProductTemplateResources productTemplateResources = new ProductTemplateResources();
+            var productTemplateResources = new ProductTemplateResources();
 
             var tagTemplate = await extractorExecutor.GenerateTagTemplateAsync(
                 "apiName1",

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/TagExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/TagExtractorTests.cs
@@ -129,5 +129,75 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             resources.Tags.Any(x => x.Name.Contains(MockTagClient.OperationTagName1)).Should().BeTrue();
             resources.Tags.Any(x => x.Name.Contains(MockTagClient.OperationTagName2)).Should().BeTrue();
         }
+
+
+        [Fact]
+        public async Task GenerateTagTemplates_GetApiRelatedTags_ProperlyLaysTheInformation()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateTagTemplates_GetApiRelatedTags_ProperlyLaysTheInformation));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration();
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var mockedTagClient = MockTagClient.GetMockedApiClientWithDefaultValues();
+            var tagExtractor = new TagExtractor(
+                this.GetTestLogger<TagExtractor>(),
+                mockedTagClient,
+                new TemplateBuilder());
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                tagExtractor: tagExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            ApiTemplateResources apiTemplateResources = new ApiTemplateResources()
+            {
+                Tags = new List<TagTemplateResource>()
+                {
+                    new TagTemplateResource()
+                    {
+                        Name = $"parameters'/{MockTagClient.TagName1}'"
+                    },
+                    new TagTemplateResource()
+                    {
+                        Name = $"parameters/{MockTagClient.TagName2}'"
+                    }
+                },
+                ApiOperationsTags = new List<TagTemplateResource>()
+                {
+                    new TagTemplateResource()
+                    {
+                        Name = $"parameters'/{MockTagClient.OperationTagName1}'"
+                    },
+                    new TagTemplateResource()
+                    {
+                        Name = $"parameters/{MockTagClient.OperationTagName2}'"
+                    }
+                }
+            };
+            ProductTemplateResources productTemplateResources = new ProductTemplateResources();
+
+            var tagTemplate = await extractorExecutor.GenerateTagTemplateAsync(
+                "apiName1",
+                apiTemplateResources,
+                productTemplateResources,
+                currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Tags)).Should().BeTrue();
+
+            tagTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
+            tagTemplate.TypedResources.Tags.Count().Should().Be(4);
+            tagTemplate.Resources.Count().Should().Be(4);
+
+            var resources = tagTemplate.TypedResources;
+
+            resources.Tags.Any(x => x.Name.Contains($"/{MockTagClient.OperationTagName1}'")).Should().BeTrue();
+            resources.Tags.Any(x => x.Name.Contains($"/{MockTagClient.OperationTagName2}'")).Should().BeTrue();
+            resources.Tags.Any(x => x.Name.Contains($"/{MockTagClient.TagName1}'")).Should().BeTrue();
+            resources.Tags.Any(x => x.Name.Contains($"/{MockTagClient.TagName2}'")).Should().BeTrue();
+        }
+
     }
 }


### PR DESCRIPTION
Added additional case (check if tag is attached to api) when tag should be extracted if apiName setting is provided for the extraction. 
