### PR TITLE
Removed whitespace from the attributes of Extractor Options 

### DIFF
--- a/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
+++ b/src/ArmTemplates/Commands/Configurations/ExtractorConsoleAppConfiguration.cs
@@ -106,10 +106,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Configu
         [Option(longName: "extractIdentityProviders", HelpText = "Extract identity providers from the service if applies")]
         public string ExtractIdentityProviders { get; set; }
 
-        [Option(longName: "parametersOutputDirectoryName ", HelpText = "Parameters output directory name, by default it is \"parameters\"")]
+        [Option(longName: "parametersOutputDirectoryName", HelpText = "Parameters output directory name, by default it is \"parameters\"")]
         public string ParametersOutputDirectoryName { get; set; }
 
-        [Option(longName: "excludeBuildInGroups ", HelpText = "Excludes built-in groups from generated template if set to \"true\"")]
+        [Option(longName: "excludeBuildInGroups", HelpText = "Excludes built-in groups from generated template if set to \"true\"")]
         public string ExcludeBuildInGroups { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Removed whitespace from the attributes of Extractor Options 
Options changed
 - parametersOutputDirectoryName
 - excludeBuildInGroups