### PR TITLE
Update PolicyExtractor.cs

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/PolicyExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/PolicyExtractor.cs
@@ -234,11 +234,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             policyTemplate.Properties.Format = "rawxml-link";
             if (extractorParameters.PolicyXMLSasToken != null)
             {
-                policyTemplate.Properties.PolicyContent = $"[concat(parameters('{ParameterNames.PolicyXMLBaseUrl}'), '{policyFileName}', parameters('{ParameterNames.PolicyXMLSasToken}'))]";
+                policyTemplate.Properties.PolicyContent = $"[concat(parameters('{ParameterNames.PolicyXMLBaseUrl}'), '/{policyFileName}', parameters('{ParameterNames.PolicyXMLSasToken}'))]";
             }
             else
             {
-                policyTemplate.Properties.PolicyContent = $"[concat(parameters('{ParameterNames.PolicyXMLBaseUrl}'), '{policyFileName}')]";
+                policyTemplate.Properties.PolicyContent = $"[concat(parameters('{ParameterNames.PolicyXMLBaseUrl}'), '/{policyFileName}')]";
             }
         }
 


### PR DESCRIPTION
There is a missing '/' in the policyTemplate builder [SetPolicyTemplateResourcePolicyContentWithArmPresetValues] That leads to deployment error 'Resource not found' in Azure DevOps.