### PR TITLE
Ignore case for policy fragment id comparison

### DIFF
--- a/src/ArmTemplates/Extractor/EntityExtractors/PolicyFragmentsExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/PolicyFragmentsExtractor.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License.
 // --------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -90,7 +91,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             {
                 var policyContent = this.policyExtractor.GetCachedPolicyContent(policyTemplateResource, baseFilesGenerationDirectory);
 
-                if (policyContent.Contains(policyFragmentReferenceString))
+                if (policyContent.Contains(policyFragmentReferenceString, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }


### PR DESCRIPTION
Closes: #836
One case found when policy fragment will not be extracted giving apiName, when the case of policy fragment id is different than referenced from resource policy content. 
Added ignoring case on comparison added specific to this case test. 