### PR TITLE
Fetch by version set name approach changed

### DIFF
--- a/src/ArmTemplates/Common/API/Clients/Abstractions/IApisClient.cs
+++ b/src/ArmTemplates/Common/API/Clients/Abstractions/IApisClient.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
     {
         Task<ApiTemplateResource> GetSingleAsync(string apiName, ExtractorParameters extractorParameters);
 
-        Task<List<ApiTemplateResource>> GetAllAsync(ExtractorParameters extractorParameters);
+        Task<List<ApiTemplateResource>> GetAllAsync(ExtractorParameters extractorParameters, bool expandVersionSet = false);
 
         Task<List<ApiTemplateResource>> GetAllCurrentAsync(ExtractorParameters extractorParameters);
 

--- a/src/ArmTemplates/Common/API/Clients/Apis/ApisClient.cs
+++ b/src/ArmTemplates/Common/API/Clients/Apis/ApisClient.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
     public class ApisClient : ApiClientBase, IApisClient
     {
         const string GetSingleApiRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis/{4}?api-version={5}";
-        const string GetAllApisRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?api-version={4}";
+        const string GetAllApisRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?api-version={4}&expandApiVersionSet={5}";
         const string GetAllCurrentApisRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/apis?api-version={4}&$filter=isCurrent";
         const string GetAllApisLinkedToProductRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/products/{4}/apis?api-version={5}";
         const string GetApisLinkedToGatewayRequest = "{0}/subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ApiManagement/service/{3}/gateways/{4}/apis?api-version={5}";
@@ -41,12 +41,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
             return api;
         }
 
-        public async Task<List<ApiTemplateResource>> GetAllAsync(ExtractorParameters extractorParameters)
+        public async Task<List<ApiTemplateResource>> GetAllAsync(ExtractorParameters extractorParameters, bool expandVersionSet = false)
         {
             var (azToken, azSubId) = await this.Auth.GetAccessToken();
             
             string requestUrl = string.Format(GetAllApisRequest,
-                this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, GlobalConstants.ApiVersion);
+                this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, GlobalConstants.ApiVersion, expandVersionSet);
 
             var apis = await this.GetPagedResponseAsync<ApiTemplateResource>(azToken, requestUrl);
             this.apiDataProcessor.ProcessData(apis);

--- a/src/ArmTemplates/Common/API/Utils/ApiClientUtils.cs
+++ b/src/ArmTemplates/Common/API/Utils/ApiClientUtils.cs
@@ -1,0 +1,56 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Utils
+{
+    public class ApiClientUtils: IApiClientUtils
+    {
+        readonly IApisClient apisClient;
+        
+        public ApiClientUtils(IApisClient apisClient)
+        {
+            this.apisClient = apisClient;
+        }
+
+        public async Task<Dictionary<string, List<string>>> GetAllAPIsDictionaryByVersionSetName(ExtractorParameters extractorParameters)
+        {
+            // pull all apis from service
+            var apis = await this.apisClient.GetAllAsync(extractorParameters, expandVersionSet: true);
+
+            // Generate apis dictionary based on all apiversionset
+            var apiDictionary = new Dictionary<string, List<string>>();
+
+            foreach (var api in apis)
+            {
+                string apiVersionSetName = api.Properties.ApiVersionSet?.Name;
+
+                if (string.IsNullOrEmpty(apiVersionSetName))
+                {
+                    continue;
+                }
+
+                if (!apiDictionary.ContainsKey(apiVersionSetName))
+                {
+                    var apiVersionSet = new List<string>
+                    {
+                        api.Name
+                    };
+                    apiDictionary[apiVersionSetName] = apiVersionSet;
+                }
+                else
+                {
+                    apiDictionary[apiVersionSetName].Add(api.Name);
+                }
+            }
+
+            return apiDictionary;
+        }
+    }
+}

--- a/src/ArmTemplates/Common/API/Utils/IApiClientUtils.cs
+++ b/src/ArmTemplates/Common/API/Utils/IApiClientUtils.cs
@@ -1,0 +1,16 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Utils
+{
+    public interface IApiClientUtils
+    {
+        Task<Dictionary<string, List<string>>> GetAllAPIsDictionaryByVersionSetName(ExtractorParameters extractorParameters);
+    }
+}

--- a/src/ArmTemplates/Common/Constants/ErrorMessages.cs
+++ b/src/ArmTemplates/Common/Constants/ErrorMessages.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants
     {
         public const string DuplicateTagResourceNameErrorMessage = "Duplicate tag resource name found during sanitizing the display name. Please consider renaming tags: {0}, {1}. Both resulted resource name to be equal to: {2}";
         public const string EmptyResourceNameAfterSanitizingErrorMessage = "Sanitizing the display name '{0}' resulted empty string";
+        public const string ApiVersionDoesNotExistErrorMessage = "API Version Set with this name doesn't exist";
     }
 }

--- a/src/ArmTemplates/Common/FileHandlers/FileNameGenerator.cs
+++ b/src/ArmTemplates/Common/FileHandlers/FileNameGenerator.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.FileHandl
                 LinkedMaster = $@"{baseFileName}master.template.json",
                 Apis = "/Apis",
                 SplitAPIs = "/SplitAPIs",
-                VersionSetMasterFolder = "/VersionSetMasterFolder",
+                VersionSetMasterFolder = "VersionSetMasterFolder",
                 RevisionMasterFolder = "/RevisionMasterFolder",
                 GroupAPIsMasterFolder = "/MultipleApisMasterFolder",
                 Groups = $"{baseFileName}groups.template.json",

--- a/src/ArmTemplates/ServiceExtensions.cs
+++ b/src/ArmTemplates/ServiceExtensions.cs
@@ -39,6 +39,7 @@ using Microsoft.Extensions.Http;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Schemas;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.OpenIdConnectProviders;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.PolicyFragments;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Utils;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates
 {
@@ -65,6 +66,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates
             SetupExtractors(services);
             SetupCreators(services);
             SetupDataProcessors(services);
+            SetupApiClientsUtils(services);
         }
 
         static void SetupDataProcessors(IServiceCollection services)
@@ -168,6 +170,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates
             services.AddScoped<ISchemasClient, SchemasClient>();
             services.AddScoped<IOpenIdConnectProvidersClient, OpenIdConnectProviderClient>();
             services.AddScoped<IPolicyFragmentsClient, PolicyFragmentsClient>();
+        }
+
+        static void SetupApiClientsUtils(IServiceCollection services)
+        {
+            services.AddScoped<IApiClientUtils, ApiClientUtils>();
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorByVersionSetNameTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorByVersionSetNameTests.cs
@@ -1,0 +1,249 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executors;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Exceptions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiManagementService;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiReleases;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Apis;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiVersionSet;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.AuthorizationServer;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Backend;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Groups;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.IdentityProviders;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Logger.Cache;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Logger;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.NamedValues;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.OpenIdConnectProviders;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Policy;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.PolicyFragments;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ProductApis;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Products;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Schemas;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.TagApi;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Tags;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abstractions;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients;
+using Moq;
+using Xunit;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
+using System.Linq;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Scenarios
+{
+    [Trait("Category", "Api By Version Set Extraction")]
+    public class ApiExtractorByVersionSetNameTests : ExtractorMockerWithOutputTestsBase
+    {
+        public ApiExtractorByVersionSetNameTests() : base("api-version-set-name-tests")
+        {
+        }
+
+        [Fact]
+        public async Task GenerateAPIVersionSetTemplates_RaisesError_GivenApiVersionSetName_DoesNotExist()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateAPIVersionSetTemplates_RaisesError_GivenApiVersionSetName_DoesNotExist));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
+                apiVersionSetName: "non-existing-api-version-set-name",
+                fileFolder: currentTestDirectory);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var responseFileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagementListApis_success_response.json");
+            var mockedApisClient = await MockApisClient.GetMockedHttpApiClient(new MockClientConfiguration(responseFileLocation: responseFileLocation));
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                apisClient: mockedApisClient);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            // act && assert
+            Func<Task> act = () => extractorExecutor.GenerateAPIVersionSetTemplates();
+            await act.Should().ThrowAsync<NoApiVersionSetWithSuchNameFoundException>().WithMessage(string.Format(ErrorMessages.ApiVersionDoesNotExistErrorMessage));
+        }
+
+        [Fact]
+        public async Task GenerateAPIVersionSetTemplates_GeneratesApiTemplates()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateAPIVersionSetTemplates_GeneratesApiTemplates));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
+                apiVersionSetName: "api-version-set-name",
+                fileFolder: currentTestDirectory);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var responseFileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagementListApis_ExpandVersionSet_success_response.json");
+            var mockedApisClient = await MockApisClient.GetMockedHttpApiClient(new MockClientConfiguration(responseFileLocation: responseFileLocation));
+
+            var mockapiExtractor = new Mock<IApiExtractor>(MockBehavior.Strict);
+            mockapiExtractor
+                .Setup(x => x.GenerateApiTemplateAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<ApiTemplateResources>()
+                {
+                    TypedResources = new ApiTemplateResources()
+                });
+
+            var mockedPolicyExtractor = new Mock<IPolicyExtractor>(MockBehavior.Strict);
+            mockedPolicyExtractor
+                .Setup(x => x.GenerateGlobalServicePolicyTemplateAsync(It.IsAny<ExtractorParameters>(), It.IsAny<string>()))
+                .ReturnsAsync(new Template<PolicyTemplateResources>());
+
+            var mockedProductApisExtractor = new Mock<IProductApisExtractor>(MockBehavior.Strict);
+            mockedProductApisExtractor
+                .Setup(x => x.GenerateProductApisTemplateAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<ProductApiTemplateResources>());
+
+            var mockedProductExtractor = new Mock<IProductExtractor>(MockBehavior.Strict);
+            mockedProductExtractor
+                .Setup(x => x.GenerateProductsTemplateAsync(It.IsAny<string>(), It.IsAny<List<ProductApiTemplateResource>>(), It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<ProductTemplateResources>()
+                {
+                });
+
+            var mockedApiVersionSetExtractor = new Mock<IApiVersionSetExtractor>(MockBehavior.Strict);
+            mockedApiVersionSetExtractor
+                .Setup(x => x.GenerateApiVersionSetTemplateAsync(It.IsAny<string>(), It.IsAny<List<ApiTemplateResource>>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<ApiVersionSetTemplateResources>());
+
+            var mockedAuthorizationServerExtractor = new Mock<IAuthorizationServerExtractor>(MockBehavior.Strict);
+            mockedAuthorizationServerExtractor
+                .Setup(x => x.GenerateAuthorizationServersTemplateAsync(It.IsAny<string>(), It.IsAny<List<ApiTemplateResource>>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<AuthorizationServerTemplateResources>());
+
+            var mockedTagsExtractor = new Mock<ITagExtractor>(MockBehavior.Strict);
+            mockedTagsExtractor
+                .Setup(x => x.GenerateTagsTemplateAsync(It.IsAny<string>(), It.IsAny<ApiTemplateResources>(), It.IsAny<ProductTemplateResources>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<TagTemplateResources>());
+
+
+            var mockedApiTagsExtractor = new Mock<ITagApiExtractor>(MockBehavior.Strict);
+            mockedApiTagsExtractor
+                .Setup(x => x.GenerateApiTagsTemplateAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<TagApiTemplateResources>());
+
+            var mockedLoggerExtractor = new Mock<ILoggerExtractor>(MockBehavior.Strict);
+            mockedLoggerExtractor
+                .Setup(x => x.GenerateLoggerTemplateAsync(It.IsAny<List<string>>(), It.IsAny<List<PolicyTemplateResource>>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<LoggerTemplateResources>()
+                {
+                    TypedResources = new LoggerTemplateResources()
+                });
+
+            mockedLoggerExtractor
+                .Setup(x => x.Cache)
+                .Returns(new LoggersCache());
+
+            var mockedNamedValuesExtractor = new Mock<INamedValuesExtractor>(MockBehavior.Strict);
+            mockedNamedValuesExtractor
+                .Setup(x => x.GenerateNamedValuesTemplateAsync(It.IsAny<string>(), It.IsAny<List<PolicyTemplateResource>>(), It.IsAny<List<LoggerTemplateResource>>(), It.IsAny<ExtractorParameters>(), It.IsAny<string>()))
+                .ReturnsAsync(new Template<NamedValuesResources>()
+                {
+                    TypedResources = new NamedValuesResources()
+                });
+
+            var mockedBackendExtractor = new Mock<IBackendExtractor>(MockBehavior.Strict);
+            mockedBackendExtractor
+                .Setup(x => x.GenerateBackendsTemplateAsync(It.IsAny<string>(), It.IsAny<List<PolicyTemplateResource>>(), It.IsAny<List<NamedValueTemplateResource>>(), It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<BackendTemplateResources>()
+                {
+                    TypedResources = new BackendTemplateResources()
+                });
+
+            var mockedGroupExtractor = new Mock<IGroupExtractor>(MockBehavior.Strict);
+            mockedGroupExtractor
+                .Setup(x => x.GenerateGroupsTemplateAsync(It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<GroupTemplateResources>());
+
+            var mockedOpenIdConnectProvidersExtractor = new Mock<IOpenIdConnectProviderExtractor>(MockBehavior.Strict);
+            mockedOpenIdConnectProvidersExtractor
+                .Setup(x => x.GenerateOpenIdConnectProvidersTemplateAsync(It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<OpenIdConnectProviderResources>()
+                {
+                    TypedResources = new OpenIdConnectProviderResources()
+                });
+
+            var mockedSchemasExtractor = new Mock<ISchemaExtractor>(MockBehavior.Strict);
+            mockedSchemasExtractor
+                .Setup(x => x.GenerateSchemasTemplateAsync(It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<SchemaTemplateResources>());
+
+            var mockedPolicyFragmentExtractor = new Mock<IPolicyFragmentsExtractor>(MockBehavior.Strict);
+            mockedPolicyFragmentExtractor
+                .Setup(x => x.GeneratePolicyFragmentsTemplateAsync(It.IsAny<List<PolicyTemplateResource>>(), It.IsAny<ExtractorParameters>(), It.IsAny<string>()))
+                .ReturnsAsync(new Template<PolicyFragmentsResources>());
+
+            var mockedApiReleasesExtractor = new Mock<IApiReleaseExtractor>(MockBehavior.Strict);
+            mockedApiReleasesExtractor
+                .Setup(x => x.GenerateCurrentApiReleaseTemplate(It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<ApiReleaseTemplateResources>());
+
+            var mockedApimServiceExtractor = new Mock<IApiManagementServiceExtractor>(MockBehavior.Strict);
+            mockedApimServiceExtractor
+                .Setup(x => x.GenerateApiManagementServicesTemplateAsync(It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template<ApiManagementServiceResources>());
+
+            var mockedParametersExtractor = new Mock<IParametersExtractor>(MockBehavior.Strict);
+            mockedParametersExtractor
+                .Setup(x => x.CreateMasterTemplateParameterValues(
+                    It.IsAny<List<string>>(),
+                    It.IsAny<LoggersCache>(),
+                    It.IsAny<LoggerTemplateResources>(),
+                    It.IsAny<BackendTemplateResources>(),
+                    It.IsAny<NamedValuesResources>(),
+                    It.IsAny<IdentityProviderResources>(),
+                    It.IsAny<OpenIdConnectProviderResources>(),
+                    It.IsAny<ExtractorParameters>()))
+                .ReturnsAsync(new Template());
+
+            mockedParametersExtractor
+                .Setup(x => x.CreateResourceTemplateParameterTemplate(It.IsAny<Template>(), It.IsAny<Template>()))
+                .Returns(new Template());
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                apisClient: mockedApisClient,
+                apiExtractor: mockapiExtractor.Object,
+                policyExtractor: mockedPolicyExtractor.Object,
+                productApisExtractor: mockedProductApisExtractor.Object,
+                productExtractor: mockedProductExtractor.Object,
+                apiVersionSetExtractor: mockedApiVersionSetExtractor.Object,
+                authorizationServerExtractor: mockedAuthorizationServerExtractor.Object,
+                tagExtractor: mockedTagsExtractor.Object,
+                tagApiExtractor: mockedApiTagsExtractor.Object,
+                loggerExtractor: mockedLoggerExtractor.Object,
+                namedValuesExtractor: mockedNamedValuesExtractor.Object,
+                backendExtractor: mockedBackendExtractor.Object,
+                groupExtractor: mockedGroupExtractor.Object,
+                openIdConnectProviderExtractor: mockedOpenIdConnectProvidersExtractor.Object,
+                schemaExtractor: mockedSchemasExtractor.Object,
+                policyFragmentsExtractor: mockedPolicyFragmentExtractor.Object,
+                apiReleaseExtractor: mockedApiReleasesExtractor.Object,
+                parametersExtractor: mockedParametersExtractor.Object,
+                apiManagementServiceExtractor: mockedApimServiceExtractor.Object
+                );
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            // act
+            await extractorExecutor.GenerateAPIVersionSetTemplates();
+
+            // assert
+            var directoriesCreated = Directory.GetDirectories(currentTestDirectory);
+            directoriesCreated.Count().Should().Be(3);
+            directoriesCreated.Any(x => x.StartsWith(Path.Combine(currentTestDirectory, "api-version-id-1"))).Should().BeTrue();
+            directoriesCreated.Any(x => x.StartsWith(Path.Combine(currentTestDirectory, "api-version-id-2"))).Should().BeTrue();
+            directoriesCreated.Any(x => x.Equals(Path.Combine(currentTestDirectory, extractorParameters.FileNames.VersionSetMasterFolder))).Should().BeTrue();
+        }
+    }
+}

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorByVersionSetNameTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorByVersionSetNameTests.cs
@@ -37,8 +37,8 @@ using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Abst
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiClients;
 using Moq;
 using Xunit;
-using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
 using System.Linq;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Utils;
 
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.Scenarios
 {
@@ -63,9 +63,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             var responseFileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagementListApis_success_response.json");
             var mockedApisClient = await MockApisClient.GetMockedHttpApiClient(new MockClientConfiguration(responseFileLocation: responseFileLocation));
 
+            var apiClientUtils = new ApiClientUtils(mockedApisClient);
+
             var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
                 this.GetTestLogger<ExtractorExecutor>(),
-                apisClient: mockedApisClient);
+                apiClientUtils: apiClientUtils);
             extractorExecutor.SetExtractorParameters(extractorParameters);
 
             // act && assert
@@ -86,6 +88,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
 
             var responseFileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagementListApis_ExpandVersionSet_success_response.json");
             var mockedApisClient = await MockApisClient.GetMockedHttpApiClient(new MockClientConfiguration(responseFileLocation: responseFileLocation));
+
+            var apiClientUtils = new ApiClientUtils(mockedApisClient);
 
             var mockapiExtractor = new Mock<IApiExtractor>(MockBehavior.Strict);
             mockapiExtractor
@@ -231,7 +235,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
                 policyFragmentsExtractor: mockedPolicyFragmentExtractor.Object,
                 apiReleaseExtractor: mockedApiReleasesExtractor.Object,
                 parametersExtractor: mockedParametersExtractor.Object,
-                apiManagementServiceExtractor: mockedApimServiceExtractor.Object
+                apiManagementServiceExtractor: mockedApimServiceExtractor.Object,
+                apiClientUtils: apiClientUtils
                 );
             extractorExecutor.SetExtractorParameters(extractorParameters);
 

--- a/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisClient.cs
+++ b/tests/ArmTemplates.Tests/Moqs/ApiClients/MockApisClient.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Moqs.ApiCl
             var serviceProperties3 = GetMockedServiceApiPropertiesWebsocket();
 
             mockedApisClient
-                .Setup(x => x.GetAllAsync(It.IsAny<ExtractorParameters>()))
-                .ReturnsAsync((ExtractorParameters _) => new List<ApiTemplateResource>
+                .Setup(x => x.GetAllAsync(It.IsAny<ExtractorParameters>(), It.IsAny<bool>()))
+                .ReturnsAsync((ExtractorParameters _, bool _) => new List<ApiTemplateResource>
                 {
                     new ApiTemplateResource
                     {

--- a/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagementListApis_ExpandVersionSet_success_response.json
+++ b/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagementListApis_ExpandVersionSet_success_response.json
@@ -1,0 +1,102 @@
+{
+  "value": [
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/a1",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "a1",
+      "properties": {
+        "displayName": "api1",
+        "apiRevision": "1",
+        "serviceUrl": "http://echoapi.cloudapp.net/api",
+        "path": "api1",
+        "protocols": [
+          "https"
+        ],
+        "isCurrent": true
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/5a73933b8f27f7cc82a2d533",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "5a73933b8f27f7cc82a2d533",
+      "properties": {
+        "displayName": "api1",
+        "apiRevision": "1",
+        "serviceUrl": "http://echoapi.cloudapp.net/api",
+        "path": "api1",
+        "protocols": [
+          "https"
+        ],
+        "isCurrent": true
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/echo-api",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "echo-api",
+      "properties": {
+        "displayName": "Echo API",
+        "apiRevision": "1",
+        "serviceUrl": "http://echoapi.cloudapp.net/api",
+        "path": "echo",
+        "protocols": [
+          "https"
+        ],
+        "isCurrent": true
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/5a7390baa5816a110435aee0",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "5a7390baa5816a110435aee0",
+      "properties": {
+        "displayName": "Swagger Petstore Extensive",
+        "apiRevision": "1",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+        "serviceUrl": "http://petstore.swagger.wordnik.com/api",
+        "path": "vvv",
+        "protocols": [
+          "https"
+        ],
+        "isCurrent": true
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/api-version-id-1",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "api-version-id-1",
+      "properties": {
+        "displayName": "api-version-id-1 name",
+        "apiRevision": "1",
+        "isCurrent": true,
+        "apiVersionSet": {
+          "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.ApiManagement/service/apimService1/apiVersionSets/api-version-set-id",
+          "name": "api-version-set-name",
+          "description": null,
+          "versioningScheme": "Segment",
+          "versionQueryName": null,
+          "versionHeaderName": null
+        }
+      }
+    },
+    {
+      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/api-version-id-2",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "api-version-id-2",
+      "properties": {
+        "displayName": "api-version-id-2 name",
+        "apiRevision": "1",
+        "isCurrent": true,
+        "apiVersionSet": {
+          "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.ApiManagement/service/apimService1/apiVersionSets/api-version-set-id",
+          "name": "api-version-set-name",
+          "description": null,
+          "versioningScheme": "Segment",
+          "versionQueryName": null,
+          "versionHeaderName": null
+        }
+      }
+    }
+  ],
+  "count": 6
+}


### PR DESCRIPTION
Change the approach of fetching all apis under version set. 
Parameter name is versionset name, but apis were extracting based on display name of the api, which could be changed. 
Closes #827 