### PR TITLE
Remove namedValue search from backend extractor

### DIFF
--- a/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
@@ -663,7 +663,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
         public async Task<Template<BackendTemplateResources>> GenerateBackendTemplateAsync(
             string singleApiName,
             List<PolicyTemplateResource> apiPolicies,
-            List<NamedValueTemplateResource> namedValueResources,
             string baseFilesGenerationDirectory)
         {
             this.logger.LogInformation("Started generation of backend template...");
@@ -671,7 +670,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             var backendTemplate = await this.backendExtractor.GenerateBackendsTemplateAsync(
                 singleApiName,
                 apiPolicies,
-                namedValueResources,
                 baseFilesGenerationDirectory,
                 this.extractorParameters);
 
@@ -1173,7 +1171,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             var apiTagTemplate = await this.GenerateTagApiTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
             var loggerTemplate = await this.GenerateLoggerTemplateAsync(apisToExtract, apiTemplate.TypedResources.GetAllPolicies(), baseFilesGenerationDirectory);
             var namedValueTemplate = await this.GenerateNamedValuesTemplateAsync(singleApiName, apiTemplate.TypedResources.GetAllPolicies(), loggerTemplate.TypedResources.Loggers, baseFilesGenerationDirectory);
-            var backendTemplate = await this.GenerateBackendTemplateAsync(singleApiName, apiTemplate.TypedResources.GetAllPolicies(), namedValueTemplate.TypedResources.NamedValues, baseFilesGenerationDirectory);
+            var backendTemplate = await this.GenerateBackendTemplateAsync(singleApiName, apiTemplate.TypedResources.GetAllPolicies(), baseFilesGenerationDirectory);
             var groupTemplate = await this.GenerateGroupsTemplateAsync(baseFilesGenerationDirectory);
             var identityProviderTemplate = await this.GenerateIdentityProviderTemplateAsync(baseFilesGenerationDirectory);
             var openIdConnectProviderTemplate = await this.GenerateOpenIdConnectProviderTemplateAsync(baseFilesGenerationDirectory);

--- a/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IBackendExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/Abstractions/IBackendExtractor.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         Task<Template<BackendTemplateResources>> GenerateBackendsTemplateAsync(
             string singleApiName,
             List<PolicyTemplateResource> apiPolicies,
-            List<NamedValueTemplateResource> namedValues,
             string baseFilesGenerationDirectory,
             ExtractorParameters extractorParameters);
 

--- a/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
@@ -160,10 +160,10 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             string backendName,
             BackendTemplateResource backendTemplateResource)
         {
-            if (backendName != null && policyContent.Contains(backendName) ||
-                backendTemplateResource.Properties.Url != null && policyContent.Contains(backendTemplateResource.Properties.Url) ||
-                backendTemplateResource.Properties.Title != null && policyContent.Contains(backendTemplateResource.Properties.Title) ||
-                backendTemplateResource.Properties.ResourceId != null && policyContent.Contains(backendTemplateResource.Properties.ResourceId))
+            if (!string.IsNullOrEmpty(backendName) && policyContent.Contains(backendName) ||
+                !string.IsNullOrEmpty(backendTemplateResource.Properties.Url) && policyContent.Contains(backendTemplateResource.Properties.Url) ||
+                !string.IsNullOrEmpty(backendTemplateResource.Properties.Title) && policyContent.Contains(backendTemplateResource.Properties.Title) ||
+                !string.IsNullOrEmpty(backendTemplateResource.Properties.ResourceId) && policyContent.Contains(backendTemplateResource.Properties.ResourceId))
             {
                 return true;
             }

--- a/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
@@ -5,8 +5,6 @@
 
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Linq;
-using System;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Policy;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Extensions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
@@ -14,7 +12,6 @@ using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtr
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Abstractions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders.Abstractions;
-using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.NamedValues;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Backend;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clients.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -48,7 +45,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         public async Task<Template<BackendTemplateResources>> GenerateBackendsTemplateAsync(
             string singleApiName,
             List<PolicyTemplateResource> apiPolicies,
-            List<NamedValueTemplateResource> namedValues,
             string baseFilesGenerationDirectory,
             ExtractorParameters extractorParameters)
         {

--- a/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/BackendExtractor.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                     {
                         var policyContent = this.policyExtractor.GetCachedPolicyContent(policyTemplateResource, baseFilesGenerationDirectory);
 
-                        if (this.DoesPolicyReferenceBackend(policyContent, namedValues, backendResource.OriginalName, backendResource))
+                        if (this.DoesPolicyReferenceBackend(policyContent, backendResource.OriginalName, backendResource))
                         {
                             // backend was used in policy, extract it
                             backendTemplate.TypedResources.Backends.Add(backendResource);
@@ -161,13 +161,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 
         bool DoesPolicyReferenceBackend(
             string policyContent,
-            IEnumerable<NamedValueTemplateResource> namedValueResources,
             string backendName,
             BackendTemplateResource backendTemplateResource)
         {
-            // a policy is referenced by a backend with the set-backend-service policy, which will reference use the backends name or url, or through referencing a named value that applies to the backend
-            var namedValueResourcesUsedByBackend = namedValueResources.Where(resource => this.DoesBackendReferenceNamedValue(resource, backendTemplateResource));
-            
             if (backendName != null && policyContent.Contains(backendName) ||
                 backendTemplateResource.Properties.Url != null && policyContent.Contains(backendTemplateResource.Properties.Url) ||
                 backendTemplateResource.Properties.Title != null && policyContent.Contains(backendTemplateResource.Properties.Title) ||
@@ -176,18 +172,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 return true;
             }
 
-            return namedValueResourcesUsedByBackend.Any(x => 
-                    (x.Properties.DisplayName is not null && policyContent.Contains(x.Properties.DisplayName)) ||
-                    (x.Properties.Value is not null && policyContent.Contains(x.Properties.Value)));
-        }
-
-        public bool DoesBackendReferenceNamedValue(NamedValueTemplateResource namedValueResource, BackendTemplateResource backendTemplateResource)
-        {
-            var namedValue = namedValueResource.Properties.Value;
-            
-            return namedValue == backendTemplateResource.Properties.Url
-                || namedValue == backendTemplateResource.Properties.Description
-                || namedValue == backendTemplateResource.Properties.Title;
+            return false;
         }
 
         public async Task<bool> IsNamedValueUsedInBackends(
@@ -233,7 +218,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                         foreach (var policyTemplateResource in apiPolicies)
                         {
                             var policyContent = this.policyExtractor.GetCachedPolicyContent(policyTemplateResource, baseFilesGenerationDirectory);
-                            if (this.DoesPolicyReferenceBackend(policyContent, Array.Empty<NamedValueTemplateResource>(), backendName, backendResource))
+                            if (this.DoesPolicyReferenceBackend(policyContent, backendName, backendResource))
                             {
                                 // don't need to go through all policies and backends if the named values has already been found
                                 return true;

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorByVersionSetNameTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiExtractorByVersionSetNameTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
 
             var mockedBackendExtractor = new Mock<IBackendExtractor>(MockBehavior.Strict);
             mockedBackendExtractor
-                .Setup(x => x.GenerateBackendsTemplateAsync(It.IsAny<string>(), It.IsAny<List<PolicyTemplateResource>>(), It.IsAny<List<NamedValueTemplateResource>>(), It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
+                .Setup(x => x.GenerateBackendsTemplateAsync(It.IsAny<string>(), It.IsAny<List<PolicyTemplateResource>>(), It.IsAny<string>(), It.IsAny<ExtractorParameters>()))
                 .ReturnsAsync(new Template<BackendTemplateResources>()
                 {
                     TypedResources = new BackendTemplateResources()

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/BackendExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/BackendExtractorTests.cs
@@ -139,5 +139,72 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             proxyBackend2.Properties.Proxy.Username.Should().Contain(ParameterNames.BackendProxy);
             proxyBackend2.Properties.Proxy.Url.Should().Contain(ParameterNames.BackendProxy);
         }
+
+        [Fact]
+        public async Task GenerateBackendTemplate_GeneratesOnlyReferencedBackendInPolicy()
+        {
+            // arrange
+            var responseFileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagementListBackends_success_response.json");
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateBackendTemplate_GeneratesOnlyReferencedBackendInPolicy));
+
+            var mockedClient = await MockBackendClient.GetMockedHttpApiClient(new MockClientConfiguration(responseFileLocation: responseFileLocation));
+            var apiName = "api-name-with-reference";
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
+                apiName: apiName);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            // mocked extractors
+            var policyExtractor = new PolicyExtractor(
+                this.GetTestLogger<PolicyExtractor>(),
+                null,
+                new TemplateBuilder());
+            
+            var backendExtractor = new BackendExtractor(
+               this.GetTestLogger<BackendExtractor>(),
+               new TemplateBuilder(),
+               policyExtractor,
+               mockedClient);
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                backendExtractor: backendExtractor,
+                policyExtractor: policyExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            var apiPolicies = new List<PolicyTemplateResource>()
+            {
+                new PolicyTemplateResource()
+                {
+                    Properties = new PolicyTemplateProperties
+                    {
+                        PolicyContent = "<set-backend-service backend-id=\"proxybackend1\" />"
+                    }
+                },
+                new PolicyTemplateResource()
+                {
+                    Properties = new PolicyTemplateProperties
+                    {
+                        PolicyContent = "<set-backend-service backend-id=\"proxybackend2\" />"
+                    }
+                }
+            };
+
+            // act
+            var backendTemplate = await extractorExecutor.GenerateBackendTemplateAsync(apiName, apiPolicies, currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Backends)).Should().BeTrue();
+
+            backendTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
+
+            backendTemplate.TypedResources.Backends.Count().Should().Be(2);
+            backendTemplate.TypedResources.Backends.All(x => x.Type.Equals(ResourceTypeConstants.Backend)).Should().BeTrue();
+
+            var proxyBackend1 = backendTemplate.TypedResources.Backends.First(x => x.Name.Contains("proxybackend1"));
+            proxyBackend1.Should().NotBeNull();
+            var proxyBackend2 = backendTemplate.TypedResources.Backends.First(x => x.Name.Contains("proxybackend2"));
+            proxyBackend2.Should().NotBeNull();
+        }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/BackendExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/BackendExtractorTests.cs
@@ -64,7 +64,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             var backendTemplate = await extractorExecutor.GenerateBackendTemplateAsync(
                 singleApiName: null,
                 new List<PolicyTemplateResource>(),
-                new List<NamedValueTemplateResource>(),
                 currentTestDirectory);
 
             // assert
@@ -117,7 +116,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             extractorExecutor.SetExtractorParameters(extractorParameters);
 
             // act
-            var backendTemplate = await extractorExecutor.GenerateBackendTemplateAsync(null, null, null, currentTestDirectory);
+            var backendTemplate = await extractorExecutor.GenerateBackendTemplateAsync(null, null, currentTestDirectory);
 
             // assert
             File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Backends)).Should().BeTrue();


### PR DESCRIPTION
Backend extractor does not needed checks for named-value references. 
Those checks are already done in NamedValues extractor which identifies relation between backend and named values 
Closes #817
