### PR TITLE
fix: Handle methodNotAllowed exception for groups

### DIFF
--- a/src/ArmTemplates/Common/API/Clients/Abstractions/ApiClientBase.cs
+++ b/src/ArmTemplates/Common/API/Clients/Abstractions/ApiClientBase.cs
@@ -31,6 +31,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
             this.httpClient = httpClientFactory.CreateClient();
         }
 
+        /// <summary>
+        ///  Main method to call trigger api management emdpoint.
+        /// </summary>
+        /// <returns>
+        /// string containing response body
+        /// bool indicating if empty default response of the requested resource should be returned
+        /// </returns>
         protected async Task<(string,bool)> CallApiManagementAsync(string azToken, string requestUrl, bool useCache = true, ClientHttpMethod method = ClientHttpMethod.GET, bool catchMethodNotAllowed = false)
         {
             if (useCache && this.cache.TryGetValue(requestUrl, out string cachedResponseBody))

--- a/src/ArmTemplates/Common/API/Clients/Groups/GroupsClient.cs
+++ b/src/ArmTemplates/Common/API/Clients/Groups/GroupsClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
             var requestUrl = string.Format(GetAllRequest,
                 this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, GlobalConstants.ApiVersion);
 
-            var groupTemplates = await this.GetPagedResponseAsync<GroupTemplateResource>(azToken, requestUrl);
+            var groupTemplates = await this.GetPagedResponseAsync<GroupTemplateResource>(azToken, requestUrl, catchMethodNotAllowed: true);
             this.groupDataProcessor.ProcessDataAllGroups(groupTemplates, extractorParameters);
 
             return groupTemplates;
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Clien
             var requestUrl = string.Format(GetAllGroupsLinkedToProductRequest,
                 this.BaseUrl, azSubId, extractorParameters.ResourceGroup, extractorParameters.SourceApimName, productName, GlobalConstants.ApiVersion);
 
-            var groupTemplates = await this.GetPagedResponseAsync<GroupTemplateResource>(azToken, requestUrl);
+            var groupTemplates = await this.GetPagedResponseAsync<GroupTemplateResource>(azToken, requestUrl, catchMethodNotAllowed: true);
             this.groupDataProcessor.ProcessDataProductLinkedGroups(groupTemplates, extractorParameters);
 
             return groupTemplates;

--- a/src/ArmTemplates/Common/API/Models/ApiErrorCodes.cs
+++ b/src/ArmTemplates/Common/API/Models/ApiErrorCodes.cs
@@ -1,0 +1,12 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Models
+{
+    public class ApiErrorCodes
+    {
+        public const string MethodNotAllowed = "MethodNotAllowedInPricingTier";
+    }
+}

--- a/src/ArmTemplates/Common/API/Models/ApiErrorProperties.cs
+++ b/src/ArmTemplates/Common/API/Models/ApiErrorProperties.cs
@@ -1,0 +1,14 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Models
+{
+    public class ApiErrorProperties
+    {
+        public string Code { get; set; }
+
+        public string Message { get; set; }
+    }
+}

--- a/src/ArmTemplates/Common/API/Models/ApiErrorResponse.cs
+++ b/src/ArmTemplates/Common/API/Models/ApiErrorResponse.cs
@@ -1,0 +1,12 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.API.Models
+{
+    public class ApiErrorResponse
+    {
+        public ApiErrorProperties Error { get; set; }
+    }
+}

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/GroupExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/GroupExtractorTests.cs
@@ -3,12 +3,15 @@
 //  Licensed under the MIT License.
 // --------------------------------------------------------------------------
 
+using System;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executors;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Constants;
+using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Exceptions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.Builders;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.EntityExtractors;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models;
@@ -93,6 +96,58 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             groupTemplate.Parameters.Should().ContainKey(ParameterNames.ApimServiceName);
             groupTemplate.TypedResources.Groups.Count().Should().Be(4);
             groupTemplate.TypedResources.Groups.First(x => x.Properties.DisplayName.Equals("AwesomeGroup for test")).Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task GenerateGroupsTemplates_DoesNotGenerateTemplate_GivenGroupListMethod_IsNotAllowed()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateGroupsTemplates_DoesNotGenerateTemplate_GivenGroupListMethod_IsNotAllowed));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
+                apiName: null);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+            var fileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagement_methodnotallowed_response.json");
+            var mockedGroupsClient = await MockGroupsClient.GetMockedHttpGroupClient(new MockClientConfiguration(responseFileLocation: fileLocation, statusCode: System.Net.HttpStatusCode.BadRequest)) ;
+            var groupExtractor = new GroupExtractor(this.GetTestLogger<GroupExtractor>(), new TemplateBuilder(), mockedGroupsClient);
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                groupExtractor: groupExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            // act
+            var groupTemplate = await extractorExecutor.GenerateGroupsTemplateAsync(currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Groups)).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GenerateGroupsTemplates_RaisesError_GivenGroupListMethod_ReturnsNotFound()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateGroupsTemplates_RaisesError_GivenGroupListMethod_ReturnsNotFound));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
+                apiName: null);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+            var fileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagement_notfound_response.json");
+            var mockedGroupsClient = await MockGroupsClient.GetMockedHttpGroupClient(new MockClientConfiguration(responseFileLocation: fileLocation, statusCode: System.Net.HttpStatusCode.NotFound));
+            var groupExtractor = new GroupExtractor(this.GetTestLogger<GroupExtractor>(), new TemplateBuilder(), mockedGroupsClient);
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                groupExtractor: groupExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            // act & assert
+            var asyncFunction = async () =>
+            {
+                await extractorExecutor.GenerateGroupsTemplateAsync(currentTestDirectory);
+            };
+            
+            var results = await asyncFunction.Should().ThrowAsync<HttpRequestException>().Where(e => e.Message.Contains("404"));
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ProductsExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ProductsExtractorTests.cs
@@ -215,57 +215,109 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             productResources.Any(x => x.OriginalName == "starter").Should().BeTrue();
         }
 
-        //new one
-        /*[Fact]
-        public async Task GenerateGroupsTemplates_DoesNotGenerateTemplate_GivenGroupListMethod_IsNotAllowed()
+        [Fact]
+        public async Task GenerateProductsTemplates_GeneratesTemplatesCorrectly_ListProductreturnsMethodNotAllowed()
         {
             // arrange
-            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateGroupsTemplates_DoesNotGenerateTemplate_GivenGroupListMethod_IsNotAllowed));
-
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateProductsTemplates_GeneratesTemplatesCorrectly_ListProductreturnsMethodNotAllowed));
             var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
-                apiName: null);
+                apiName: null
+            );
             var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var getAlldProductsResponseFileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagementListProducts_success_response.json");
+            var mockedProductsClient = await MockProductsClient.GetMockedHttpProductClient(
+                new MockClientConfiguration(responseFileLocation: getAlldProductsResponseFileLocation, urlPath: $"{MockSourceApimName}/products?api-version={GlobalConstants.ApiVersion}")
+            );
+
+            //default values
             var fileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagement_methodnotallowed_response.json");
             var mockedGroupsClient = await MockGroupsClient.GetMockedHttpGroupClient(new MockClientConfiguration(responseFileLocation: fileLocation, statusCode: System.Net.HttpStatusCode.BadRequest));
-            var groupExtractor = new GroupExtractor(this.GetTestLogger<GroupExtractor>(), new TemplateBuilder(), mockedGroupsClient);
+
+            var mockedTagClient = MockTagClient.GetMockedApiClientWithEmptytValues();
+
+            var mockedPolicyClient = MockPolicyClient.GetMockedApiClientWithEmptyValues();
+            var mockedPolicyExtractor = new PolicyExtractor(this.GetTestLogger<PolicyExtractor>(), mockedPolicyClient, new TemplateBuilder());
+
+            var productExtractor = new ProductExtractor(
+                this.GetTestLogger<ProductExtractor>(),
+                mockedPolicyExtractor,
+                mockedProductsClient,
+                mockedGroupsClient,
+                mockedTagClient,
+                new TemplateBuilder());
 
             var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
                 this.GetTestLogger<ExtractorExecutor>(),
-                groupExtractor: groupExtractor);
+                productExtractor: productExtractor);
             extractorExecutor.SetExtractorParameters(extractorParameters);
 
             // act
-            var groupTemplate = await extractorExecutor.GenerateGroupsTemplateAsync(currentTestDirectory);
+            var productTemplate = await extractorExecutor.GenerateProductsTemplateAsync(
+                singleApiName: null,
+                currentTestDirectory);
 
             // assert
-            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Groups)).Should().BeFalse();
+            // generated product template files
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Products)).Should().BeTrue();
+
+            var templateParameters = productTemplate.Parameters;
+            templateParameters.Should().ContainKey(ParameterNames.ApimServiceName);
+
+            var templateResources = productTemplate.Resources;
+            // product resource
+            var productResources = templateResources.Where(x => x.Type == ResourceTypeConstants.Product).ToList();
+            productResources.Count.Should().Be(2);
+            productResources.Any(x => x.OriginalName == "unlimited").Should().BeTrue();
+            productResources.Any(x => x.OriginalName == "starter").Should().BeTrue();
         }
 
         [Fact]
-        public async Task GenerateGroupsTemplates_RaisesError_GivenGroupListMethod_ReturnsNotFound()
+        public async Task GenerateProductsTemplates_RaisesError_GivenGroupListMethod_ReturnsNotFound()
         {
             // arrange
-            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateGroupsTemplates_RaisesError_GivenGroupListMethod_ReturnsNotFound));
-
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateProductsTemplates_RaisesError_GivenGroupListMethod_ReturnsNotFound));
             var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
-                apiName: null);
+                apiName: null
+            );
             var extractorParameters = new ExtractorParameters(extractorConfig);
+
+            var getAlldProductsResponseFileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagementListProducts_success_response.json");
+            var mockedProductsClient = await MockProductsClient.GetMockedHttpProductClient(
+                new MockClientConfiguration(responseFileLocation: getAlldProductsResponseFileLocation, urlPath: $"{MockSourceApimName}/products?api-version={GlobalConstants.ApiVersion}")
+            );
+
+            //default values
             var fileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagement_notfound_response.json");
             var mockedGroupsClient = await MockGroupsClient.GetMockedHttpGroupClient(new MockClientConfiguration(responseFileLocation: fileLocation, statusCode: System.Net.HttpStatusCode.NotFound));
-            var groupExtractor = new GroupExtractor(this.GetTestLogger<GroupExtractor>(), new TemplateBuilder(), mockedGroupsClient);
+
+            var mockedTagClient = MockTagClient.GetMockedApiClientWithEmptytValues();
+
+            var mockedPolicyClient = MockPolicyClient.GetMockedApiClientWithEmptyValues();
+            var mockedPolicyExtractor = new PolicyExtractor(this.GetTestLogger<PolicyExtractor>(), mockedPolicyClient, new TemplateBuilder());
+
+            var productExtractor = new ProductExtractor(
+                this.GetTestLogger<ProductExtractor>(),
+                mockedPolicyExtractor,
+                mockedProductsClient,
+                mockedGroupsClient,
+                mockedTagClient,
+                new TemplateBuilder());
 
             var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
                 this.GetTestLogger<ExtractorExecutor>(),
-                groupExtractor: groupExtractor);
+                productExtractor: productExtractor);
             extractorExecutor.SetExtractorParameters(extractorParameters);
 
-            // act & assert
+            // act
             var asyncFunction = async () =>
             {
-                await extractorExecutor.GenerateGroupsTemplateAsync(currentTestDirectory);
+                await extractorExecutor.GenerateProductsTemplateAsync(
+                singleApiName: null,
+                currentTestDirectory);
             };
 
-            var results = await asyncFunction.Should().ThrowAsync<HttpRequestException>().Where(e => e.Message.Contains("404"));
-        }*/
+            await asyncFunction.Should().ThrowAsync<HttpRequestException>().Where(e => e.Message.Contains("404"));
+        }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ProductsExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ProductsExtractorTests.cs
@@ -5,6 +5,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executors;
@@ -213,5 +214,58 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
             productResources.Any(x => x.OriginalName == "unlimited").Should().BeTrue();
             productResources.Any(x => x.OriginalName == "starter").Should().BeTrue();
         }
+
+        //new one
+        /*[Fact]
+        public async Task GenerateGroupsTemplates_DoesNotGenerateTemplate_GivenGroupListMethod_IsNotAllowed()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateGroupsTemplates_DoesNotGenerateTemplate_GivenGroupListMethod_IsNotAllowed));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
+                apiName: null);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+            var fileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagement_methodnotallowed_response.json");
+            var mockedGroupsClient = await MockGroupsClient.GetMockedHttpGroupClient(new MockClientConfiguration(responseFileLocation: fileLocation, statusCode: System.Net.HttpStatusCode.BadRequest));
+            var groupExtractor = new GroupExtractor(this.GetTestLogger<GroupExtractor>(), new TemplateBuilder(), mockedGroupsClient);
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                groupExtractor: groupExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            // act
+            var groupTemplate = await extractorExecutor.GenerateGroupsTemplateAsync(currentTestDirectory);
+
+            // assert
+            File.Exists(Path.Combine(currentTestDirectory, extractorParameters.FileNames.Groups)).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GenerateGroupsTemplates_RaisesError_GivenGroupListMethod_ReturnsNotFound()
+        {
+            // arrange
+            var currentTestDirectory = Path.Combine(this.OutputDirectory, nameof(GenerateGroupsTemplates_RaisesError_GivenGroupListMethod_ReturnsNotFound));
+
+            var extractorConfig = this.GetDefaultExtractorConsoleAppConfiguration(
+                apiName: null);
+            var extractorParameters = new ExtractorParameters(extractorConfig);
+            var fileLocation = Path.Combine(MockClientUtils.ApiClientJsonResponsesPath, "ApiManagement_notfound_response.json");
+            var mockedGroupsClient = await MockGroupsClient.GetMockedHttpGroupClient(new MockClientConfiguration(responseFileLocation: fileLocation, statusCode: System.Net.HttpStatusCode.NotFound));
+            var groupExtractor = new GroupExtractor(this.GetTestLogger<GroupExtractor>(), new TemplateBuilder(), mockedGroupsClient);
+
+            var extractorExecutor = ExtractorExecutor.BuildExtractorExecutor(
+                this.GetTestLogger<ExtractorExecutor>(),
+                groupExtractor: groupExtractor);
+            extractorExecutor.SetExtractorParameters(extractorParameters);
+
+            // act & assert
+            var asyncFunction = async () =>
+            {
+                await extractorExecutor.GenerateGroupsTemplateAsync(currentTestDirectory);
+            };
+
+            var results = await asyncFunction.Should().ThrowAsync<HttpRequestException>().Where(e => e.Message.Contains("404"));
+        }*/
     }
 }

--- a/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagement_methodnotallowed_response.json
+++ b/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagement_methodnotallowed_response.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "MethodNotAllowedInPricingTier",
+    "message": "Method not allowed in pricing tier",
+    "details": null
+  }
+}

--- a/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagement_notfound_response.json
+++ b/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagement_notfound_response.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "ResourceNotFound",
+    "message": "resource not found.",
+    "details": null
+  }
+}


### PR DESCRIPTION
Closes: #849.
Endpoint for fetching groups (all, linked to product) returns 400 bad request for consumption tier. 
The change introduces possibility to bypass and return empty result even if groups are not allowed, to continue full extraction. 