### PR TITLE
fix: Add `type`, `values` and `required` properties to api operation header structure

### DIFF
--- a/src/ArmTemplates/Common/Templates/ApiOperations/ApiOperationHeader.cs
+++ b/src/ArmTemplates/Common/Templates/ApiOperations/ApiOperationHeader.cs
@@ -12,5 +12,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
         public string Description { get; set; }
 
         public string Name { get; set; }
+
+        public string Type { get; set; }
+
+        public string[] Values { get; set; }
     }
 }

--- a/src/ArmTemplates/Common/Templates/ApiOperations/ApiOperationHeader.cs
+++ b/src/ArmTemplates/Common/Templates/ApiOperations/ApiOperationHeader.cs
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License.
 // --------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates.ApiOperations
 {
     public class ApiOperationHeader
@@ -15,6 +17,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Common.Templates
 
         public string Type { get; set; }
 
-        public string[] Values { get; set; }
+        public string[] Values { get; set; } = Array.Empty<string>();
+
+        public bool Required { get; set; }
     }
 }

--- a/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiOperationExtractorTests.cs
+++ b/tests/ArmTemplates.Tests/Extractor/Scenarios/ApiOperationExtractorTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
 {
     [Trait("Category", "Api operations Extraction")]
     public class ApiOperationExtractorTests : ExtractorMockerWithOutputTestsBase
-    {        
+    {
         public ApiOperationExtractorTests() : base("api-operations-tests")
         {
         }
@@ -43,6 +43,24 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Tests.Extractor.
 
             var exampleDefault = submitOrderOperation.Properties.Request.Representations[0].Examples["default"];
             exampleDefault.Value.Should().Be("[[{\"key\":\"value\"}]");
+
+            var preferHeader = submitOrderOperation.Properties.Request.Headers.First(h => h.Name == "Prefer");
+            preferHeader.Values.Should().Equal(new[] { "return=minimal", "return=representation" });
+            preferHeader.DefaultValue.Should().Be("return=minimal");
+            preferHeader.Type.Should().Be("string");
+            preferHeader.Required.Should().BeFalse();
+
+            var authorizationHeader = submitOrderOperation.Properties.Request.Headers.First(h => h.Name == "Authorization");
+            authorizationHeader.Values.Should().BeEmpty();
+            authorizationHeader.DefaultValue.Should().BeNull();
+            authorizationHeader.Type.Should().Be("string");
+            authorizationHeader.Required.Should().BeTrue();
+
+            var maxCountHeader = submitOrderOperation.Properties.Request.Headers.First(h => h.Name == "MaxCount");
+            maxCountHeader.Values.Should().BeEmpty();
+            maxCountHeader.DefaultValue.Should().Be("100");
+            maxCountHeader.Type.Should().Be("integer");
+            maxCountHeader.Required.Should().BeFalse();
         }
     }
 }

--- a/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagementListApiOperations_success_response.json
+++ b/tests/ArmTemplates.Tests/Resources/ApiClientJsonResponses/ApiManagementListApiOperations_success_response.json
@@ -63,6 +63,31 @@
         "urlTemplate": "/?soapAction=http://tempuri.org/IFazioService/submitOrder",
         "request": {
           "description": "description",
+          "headers": [
+            {
+              "name": "Prefer",
+              "description": "Indicates a level of details in the response. This operation supports 'return=representation' and 'return=minimal' preferences.",
+              "type": "string",
+              "defaultValue": "return=minimal",
+              "values": [
+                "return=minimal",
+                "return=representation"
+              ]
+            },
+            {
+              "name": "Authorization",
+              "description": "OAuth access token",
+              "type": "string",
+              "required": true,
+              "values": []
+            },
+            {
+              "name": "MaxCount",
+              "description": "Max number of items",
+              "type": "integer",
+              "defaultValue": "100"
+            }
+          ],
           "representations": [
             {
               "contentType": "application/json",


### PR DESCRIPTION
Fixes #862 - header properties are missing from extracted template

