### PR TITLE
fix: Determine the sku for groups extraction

### DIFF
--- a/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ArmTemplates/Commands/Executors/ExtractorExecutor.cs
@@ -878,6 +878,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
 
             if (apiManagementServiceTemplate?.HasResources() == true)
             {
+
+                var typedService = apiManagementServiceTemplate.TypedResources.ApiManagementServices.FirstOrDefault();
+                if (typedService.Sku is not null)
+                {
+                    this.extractorParameters.SetSkuType(typedService.Sku.Name);
+                }
+                
                 await FileWriter.SaveAsJsonAsync(
                     apiManagementServiceTemplate,
                     directory: baseFilesGenerationDirectory,
@@ -1156,6 +1163,9 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             {
                 throw new SingleAndMultipleApisCanNotExistTogetherException("Can't specify single API and multiple APIs to extract at the same time");
             }
+            
+            // Fetch ApiManagement Service instance template 
+            await this.GenerateApiManagementServiceTemplate(baseFilesGenerationDirectory);
 
             var apisToExtract = await this.GetApiNamesToExtract(singleApiName, multipleApiNames);
             // generate different templates using extractors and write to output
@@ -1179,7 +1189,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             var apiReleasesTemplate = await this.GenerateApiReleasesTemplateAsync(baseFilesGenerationDirectory);
             await this.GenerateGatewayTemplateAsync(singleApiName, baseFilesGenerationDirectory);
             await this.GenerateGatewayApiTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
-            await this.GenerateApiManagementServiceTemplate(baseFilesGenerationDirectory);
             
             var parametersTemplate = await this.GenerateParametersTemplateAsync(apisToExtract, loggerTemplate.TypedResources, backendTemplate.TypedResources, namedValueTemplate.TypedResources, identityProviderTemplate.TypedResources, openIdConnectProviderTemplate.TypedResources, baseFilesGenerationDirectory);
             

--- a/src/ArmTemplates/Extractor/EntityExtractors/GroupExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/GroupExtractor.cs
@@ -40,6 +40,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                                         .GenerateTemplateWithApimServiceNameProperty()
                                         .Build<GroupTemplateResources>();
 
+            if (SKUTypes.IsConsumption(extractorParameters.CurrentSKU))
+            {
+                this.logger.LogInformation("Skipping generation of groups template for consumption sku...");
+                return groupsTemplate;
+            }
+
             var allGroups = await this.groupsClient.GetAllAsync(extractorParameters);
             if (allGroups.IsNullOrEmpty())
             {

--- a/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
+++ b/src/ArmTemplates/Extractor/EntityExtractors/ProductExtractor.cs
@@ -159,6 +159,12 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         {
             var productResourceId = new string[] { $"[resourceId('Microsoft.ApiManagement/service/products', parameters('{ParameterNames.ApimServiceName}'), '{productTemplateResource.NewName}')]" };
 
+            if (SKUTypes.IsConsumption(extractorParameters.CurrentSKU))
+            {
+                this.logger.LogInformation("Skipping generation of groups resources attached to groups for consumption sku...");
+                return ;
+            }
+
             try
             {
                 var groupsLinkedToProduct = await this.groupsClient.GetAllLinkedToProductAsync(productTemplateResource.OriginalName, extractorParameters);
@@ -178,6 +184,5 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
                 throw;
             }
         }
-
     }
 }

--- a/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
+++ b/src/ArmTemplates/Extractor/Models/ExtractorParameters.cs
@@ -96,6 +96,13 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
 
         public Dictionary<string, ApiParameterProperty> ApiParameters { get; private set; }
 
+        public string CurrentSKU { get; private set; }
+
+        public void SetSkuType(string sku)
+        {
+            this.CurrentSKU = sku;
+        }
+
         public ExtractorParameters(ExtractorConsoleAppConfiguration extractorConfig)
         {
             this.SourceApimName = extractorConfig.SourceApimName;

--- a/src/ArmTemplates/Extractor/Models/SKUValues.cs
+++ b/src/ArmTemplates/Extractor/Models/SKUValues.cs
@@ -1,0 +1,30 @@
+﻿// --------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+// --------------------------------------------------------------------------
+
+
+using System;
+
+namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Models
+{
+    public class SKUTypes
+    {
+        public const string Basic = "Basic";
+        public const string Consumption = "Consumption";
+        public const string Developer = "Developer";
+        public const string Isolated = "Isolated";
+        public const string Premium = "Premium";
+        public const string Standard = "Standard";
+
+        public static bool IsConsumption(string skuValue)
+        {
+            if (string.IsNullOrEmpty(skuValue))
+            {
+                return false;
+            }
+
+            return skuValue.Equals(Consumption, StringComparison.CurrentCultureIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
Closes #849.
Fetching of apim service happens before extraction of other resources, sets the value of the current sku which referenced from extractors if needed to determine if it is available. 
https://learn.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-management-service/get?tabs=HTTP#skutype